### PR TITLE
Added BSShaderTextureSets merging

### DIFF
--- a/src/spells/optimize.cpp
+++ b/src/spells/optimize.cpp
@@ -61,12 +61,12 @@ public:
 						nif->set<QString>( iBlock, "Name", "Default" );
 				}
 
-				if ( nif->inherits( iBlock, "BSShaderProperty" ) || nif->isNiBlock( iBlock, "BSShaderTextureSet" ) ) {
+				if ( nif->inherits( iBlock, "BSShaderProperty" ) ) {
 					// these need to be unique
 					continue;
 				}
 
-				if ( nif->inherits( iBlock, "NiProperty" ) || nif->inherits( iBlock, "NiSourceTexture" ) ) {
+				if ( nif->inherits( iBlock, "NiProperty" ) || nif->inherits( iBlock, "NiSourceTexture" ) || nif->isNiBlock( iBlock, "BSShaderTextureSet" ) ) {
 					QBuffer data;
 					data.open( QBuffer::WriteOnly );
 					data.write( nif->itemName( iBlock ).toLatin1() );


### PR DESCRIPTION
"Combine Properties" Spell now combines identical BSShaderTextureSets.
Checked if BSShaderTextureSets could be merged in Fallout 3, NV and Skyrim and found evidence in vanilla Skyrim .nif files that they are actually meant to be merged.
