### PR TITLE
Allows for compilation on Linux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "docsys"]
 	path = build/docsys
 	url = https://github.com/niftools/nifdocsys.git
-	branch = develop
 [submodule "qhull"]
 	path = lib/qhull
 	url = https://github.com/qhull/qhull.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,10 @@
 [submodule "docsys"]
 	path = build/docsys
-	url = git://github.com/niftools/nifdocsys.git
+	url = https://github.com/niftools/nifdocsys.git
+	branch = develop
 [submodule "qhull"]
 	path = lib/qhull
-	url = git@github.com:qhull/qhull.git
+	url = https://github.com/qhull/qhull.git
 [submodule "lib/zlib"]
 	path = lib/zlib
-	url = git@github.com:madler/zlib.git
+	url = https://github.com/madler/zlib.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,14 @@ language: cpp
 addons:
   apt:
     sources:
+      - sourceline: 'ppa:beineri/opt-qt551-trusty'
       - ubuntu-toolchain-r-test
     packages: [
       # static analysis
       clang-3.6,
       # qt5 requirement
-      qt5-qmake, qt5-default, qtbase5-dev
+      #qt5-qmake, qt5-default, qtbase5-dev
+      qt-latest
     ]
     
 
@@ -32,7 +34,8 @@ matrix:
       python: nightly
 
 before_install:
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then sudo apt purge qt4-qmake libqt4-dev; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then QT_ENV_SCRIPT=$(find /opt -name 'qt*-env.sh'); source $QT_ENV_SCRIPT; fi
+#  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then sudo apt purge qt4-qmake libqt4-dev; fi
 
 script:
   - qmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,14 @@ language: cpp
 addons:
   apt:
     sources:
-    - ubuntu-toolchain-r-test
-    - debian-sid
-    packages:
-    - qt5-qmake
+      - ubuntu-toolchain-r-test
+    packages: [
+      # static analysis
+      clang-3.6,
+      # qt5 requirement
+      qt5-qmake, qt5-default, qtbase5-dev
+    ]
+    
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 dist: trusty
-osx_image: xcode7.2
 sudo: required
 language: cpp
 os:
   - linux
-#  - osx
+  - osx
 addons:
   apt:
     sources:
@@ -27,6 +26,7 @@ matrix:
 
 before_install:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then QT_ENV_SCRIPT=$(find /opt -name 'qt*-env.sh'); source $QT_ENV_SCRIPT; fi
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update; brew install qt@5.5; export PATH="/usr/local/opt/qt@5.5/bin:$PATH"; fi
 
 script:
   - qmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+dist: trusty
+osx_image: xcode8.2
+sudo: required
+language: cpp
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    - debian-sid
+    packages:
+    - qt5-qmake
+
+matrix:
+  fast_finish: true
+  include:
+    - os: linux
+      python: 3.3
+    - os: linux
+      python: 3.4
+    - os: linux
+      python: 3.5
+    - os: linux
+      python: 3.6
+    - os: linux
+      python: nightly
+    - os: osx
+      python: nightly
+
+before_install:
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then sudo apt purge qt4-qmake libqt4-dev; fi
+
+script:
+  - qmake --version
+  - qmake -makefile NifSkope.pro
+  - make -j4
+
+notifications:
+    email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,46 +1,37 @@
 dist: trusty
-osx_image: xcode8.2
+osx_image: xcode7.2
 sudo: required
 language: cpp
-
+os:
+  - linux
+#  - osx
 addons:
   apt:
     sources:
       - sourceline: 'ppa:beineri/opt-qt551-trusty'
-      - ubuntu-toolchain-r-test
     packages: [
       # static analysis
       clang-3.6,
       # qt5 requirement
-      #qt5-qmake, qt5-default, qtbase5-dev
-      qt-latest
+      qt55-meta-minimal
     ]
-    
-
 matrix:
   fast_finish: true
   include:
     - os: linux
-      python: 3.3
-    - os: linux
-      python: 3.4
-    - os: linux
-      python: 3.5
-    - os: linux
-      python: 3.6
-    - os: linux
-      python: nightly
-    - os: osx
-      python: nightly
+      env:
+        ANALYZE="scan-build-3.6 --use-cc clang-3.6 --use-c++ clang++-3.6 "
+      compiler: clang
+  allow_failures:
+    - env: ANALYZE="scan-build-3.6 --use-cc clang-3.6 --use-c++ clang++-3.6 "
 
 before_install:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then QT_ENV_SCRIPT=$(find /opt -name 'qt*-env.sh'); source $QT_ENV_SCRIPT; fi
-#  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then sudo apt purge qt4-qmake libqt4-dev; fi
 
 script:
   - qmake --version
   - qmake -makefile NifSkope.pro
-  - make -j4
+  - ${ANALYZE}make -j4
 
 notifications:
     email: false

--- a/NifSkope.pro
+++ b/NifSkope.pro
@@ -9,27 +9,26 @@ QT += xml opengl network widgets
 
 # Require Qt 5.5 or higher
 contains(QT_VERSION, ^5\\.[0-4]\\..*) {
-	message("Cannot build NifSkope with Qt version $${QT_VERSION}")
-	error("Minimum required version is Qt 5.5")
+        message("Cannot build NifSkope with Qt version $${QT_VERSION}")
+        error("Minimum required version is Qt 5.5")
 }
 
 # C++11 Support
 CONFIG += c++11
 
 # Dependencies
-CONFIG += nvtristrip qhull soil zlib lz4
-win32:CONFIG += fsengine
+CONFIG += nvtristrip qhull soil zlib lz4 fsengine
 
 # Debug/Release options
 CONFIG(debug, debug|release) {
-	# Debug Options
-	BUILD = debug
-	CONFIG += console
+        # Debug Options
+        BUILD = debug
+        CONFIG += console
 } else {
-	# Release Options
-	BUILD = release
-	CONFIG -= console
-	DEFINES += QT_NO_DEBUG_OUTPUT
+        # Release Options
+        BUILD = release
+        CONFIG -= console
+        DEFINES += QT_NO_DEBUG_OUTPUT
 }
 # TODO: Get rid of this define
 #	uncomment this if you want the text stats gl option
@@ -38,43 +37,43 @@ CONFIG(debug, debug|release) {
 INCLUDEPATH += src lib
 
 TRANSLATIONS += \
-	res/lang/NifSkope_de.ts \
-	res/lang/NifSkope_fr.ts
+        res/lang/NifSkope_de.ts \
+        res/lang/NifSkope_fr.ts
 
 # Require explicit
 DEFINES += \
-	QT_NO_CAST_FROM_BYTEARRAY \ # QByteArray deprecations
-	QT_NO_URL_CAST_FROM_STRING \ # QUrl deprecations
-	QT_DISABLE_DEPRECATED_BEFORE=0x050300 #\ # Disable all functions deprecated as of 5.3
+        QT_NO_CAST_FROM_BYTEARRAY \ # QByteArray deprecations
+        QT_NO_URL_CAST_FROM_STRING \ # QUrl deprecations
+        QT_DISABLE_DEPRECATED_BEFORE=0x050300 #\ # Disable all functions deprecated as of 5.3
 
-	# Useful for tracking down strings not using
-	#	QObject::tr() for translations.
-	# QT_NO_CAST_FROM_ASCII \
-	# QT_NO_CAST_TO_ASCII
+        # Useful for tracking down strings not using
+        #	QObject::tr() for translations.
+        # QT_NO_CAST_FROM_ASCII \
+        # QT_NO_CAST_TO_ASCII
 
 
 VISUALSTUDIO = false
 *msvc* {
-	######################################
-	## Detect Visual Studio vs Qt Creator
-	######################################
-	#	Qt Creator = shadow build
-	#	Visual Studio = no shadow build
+        ######################################
+        ## Detect Visual Studio vs Qt Creator
+        ######################################
+        #	Qt Creator = shadow build
+        #	Visual Studio = no shadow build
 
-	# Strips PWD (source) from OUT_PWD (build) to test if they are on the same path
-	#	- contains() does not work
-	#	- equals( PWD, $${OUT_PWD} ) is not sufficient
-	REP = $$replace(OUT_PWD, $${PWD}, "")
+        # Strips PWD (source) from OUT_PWD (build) to test if they are on the same path
+        #	- contains() does not work
+        #	- equals( PWD, $${OUT_PWD} ) is not sufficient
+        REP = $$replace(OUT_PWD, $${PWD}, "")
 
-	# Test if Build dir is outside Source dir
-	#	if REP == OUT_PWD, not Visual Studio
-	!equals( REP, $${OUT_PWD} ):VISUALSTUDIO = true
-	unset(REP)
+        # Test if Build dir is outside Source dir
+        #	if REP == OUT_PWD, not Visual Studio
+        !equals( REP, $${OUT_PWD} ):VISUALSTUDIO = true
+        unset(REP)
 
-	# Set OUT_PWD to ./bin so that qmake doesn't clutter PWD
-	#	Unfortunately w/ VS qmake still creates empty debug/release folders in PWD.
-	#	They are never used but get auto-generated because of CONFIG += debug_and_release
-	$$VISUALSTUDIO:OUT_PWD = $${_PRO_FILE_PWD_}/bin
+        # Set OUT_PWD to ./bin so that qmake doesn't clutter PWD
+        #	Unfortunately w/ VS qmake still creates empty debug/release folders in PWD.
+        #	They are never used but get auto-generated because of CONFIG += debug_and_release
+        $$VISUALSTUDIO:OUT_PWD = $${_PRO_FILE_PWD_}/bin
 }
 
 ###############################
@@ -98,7 +97,7 @@ DEFINES += NIFSKOPE_VERSION=\\\"$${VER}\\\"
 
 # NIFSKOPE_REVISION macro
 !isEmpty(REVISION) {
-	DEFINES += NIFSKOPE_REVISION=\\\"$${REVISION}\\\"
+        DEFINES += NIFSKOPE_REVISION=\\\"$${REVISION}\\\"
 }
 
 
@@ -109,22 +108,22 @@ DEFINES += NIFSKOPE_VERSION=\\\"$${VER}\\\"
 # build_pass is necessary
 # Otherwise it will create empty .moc, .ui, etc. dirs on the drive root
 build_pass|!debug_and_release {
-	win32:equals( VISUALSTUDIO, true ) {
-		# Visual Studio
-		DESTDIR = $${_PRO_FILE_PWD_}/bin/$${BUILD}
-		# INTERMEDIATE FILES
-		INTERMEDIATE = $${DESTDIR}/../GeneratedFiles/$${BUILD}
-	} else {
-		# Qt Creator
-		DESTDIR = $${OUT_PWD}/$${BUILD}
-		# INTERMEDIATE FILES
-		INTERMEDIATE = $${DESTDIR}/../GeneratedFiles/
-	}
+        win32:equals( VISUALSTUDIO, true ) {
+                # Visual Studio
+                DESTDIR = $${_PRO_FILE_PWD_}/bin/$${BUILD}
+                # INTERMEDIATE FILES
+                INTERMEDIATE = $${DESTDIR}/../GeneratedFiles/$${BUILD}
+        } else {
+                # Qt Creator
+                DESTDIR = $${OUT_PWD}/$${BUILD}
+                # INTERMEDIATE FILES
+                INTERMEDIATE = $${DESTDIR}/../GeneratedFiles/
+        }
 
-	UI_DIR = $${INTERMEDIATE}/.ui
-	MOC_DIR = $${INTERMEDIATE}/.moc
-	RCC_DIR = $${INTERMEDIATE}/.qrc
-	OBJECTS_DIR = $${INTERMEDIATE}/.obj
+        UI_DIR = $${INTERMEDIATE}/.ui
+        MOC_DIR = $${INTERMEDIATE}/.moc
+        RCC_DIR = $${INTERMEDIATE}/.qrc
+        OBJECTS_DIR = $${INTERMEDIATE}/.obj
 }
 
 ###############################
@@ -139,170 +138,171 @@ include(NifSkope_targets.pri)
 ###############################
 
 HEADERS += \
-	src/basemodel.h \
-	src/config.h \
-	src/gl/dds/BlockDXT.h \
-	src/gl/dds/Color.h \
-	src/gl/dds/ColorBlock.h \
-	src/gl/dds/Common.h \
-	src/gl/dds/dds_api.h \
-	src/gl/dds/DirectDrawSurface.h \
-	src/gl/dds/Image.h \
-	src/gl/dds/PixelFormat.h \
-	src/gl/dds/Stream.h \
-	src/gl/controllers.h \
-	src/gl/glcontroller.h \
-	src/gl/glmarker.h \
-	src/gl/glmesh.h \
-	src/gl/glnode.h \
-	src/gl/glparticles.h \
-	src/gl/glproperty.h \
-	src/gl/glscene.h \
-	src/gl/gltex.h \
-	src/gl/gltexloaders.h \
-	src/gl/gltools.h \
-	src/gl/icontrollable.h \
-	src/gl/marker/constraints.h \
-	src/gl/marker/furniture.h \
-	src/gl/renderer.h \
-	src/glview.h \
-	src/importex/3ds.h \
-	src/kfmmodel.h \
-	src/message.h \
-	src/nifexpr.h \
-	src/nifitem.h \
-	src/nifmodel.h \
-	src/nifproxy.h \
-	src/nifskope.h \
-	src/niftypes.h \
-	src/nifvalue.h \
+        src/basemodel.h \
+        src/config.h \
+        src/gl/dds/BlockDXT.h \
+        src/gl/dds/Color.h \
+        src/gl/dds/ColorBlock.h \
+        src/gl/dds/Common.h \
+        src/gl/dds/dds_api.h \
+        src/gl/dds/DirectDrawSurface.h \
+        src/gl/dds/Image.h \
+        src/gl/dds/PixelFormat.h \
+        src/gl/dds/Stream.h \
+        src/gl/controllers.h \
+        src/gl/glcontroller.h \
+        src/gl/glmarker.h \
+        src/gl/glmesh.h \
+        src/gl/glnode.h \
+        src/gl/glparticles.h \
+        src/gl/glproperty.h \
+        src/gl/glscene.h \
+        src/gl/gltex.h \
+        src/gl/gltexloaders.h \
+        src/gl/gltools.h \
+        src/gl/icontrollable.h \
+        src/gl/marker/constraints.h \
+        src/gl/marker/furniture.h \
+        src/gl/renderer.h \
+        src/glview.h \
+        src/importex/3ds.h \
+        src/kfmmodel.h \
+        src/message.h \
+        src/nifexpr.h \
+        src/nifitem.h \
+        src/nifmodel.h \
+        src/nifproxy.h \
+        src/nifskope.h \
+        src/niftypes.h \
+        src/nifvalue.h \
     src/nvtristripwrapper.h \
-	src/qhull.h \
-	src/settings.h \
-	src/spellbook.h \
-	src/spells/blocks.h \
-	src/spells/mesh.h \
-	src/spells/misc.h \
-	src/spells/skeleton.h \
-	src/spells/stringpalette.h \
-	src/spells/tangentspace.h \
-	src/spells/texture.h \
-	src/spells/transform.h \
-	src/widgets/colorwheel.h \
-	src/widgets/fileselect.h \
-	src/widgets/floatedit.h \
-	src/widgets/floatslider.h \
-	src/widgets/groupbox.h \
-	src/widgets/inspect.h \
-	src/widgets/nifcheckboxlist.h \
-	src/widgets/nifeditors.h \
-	src/widgets/nifview.h \
-	src/widgets/refrbrowser.h \
-	src/widgets/uvedit.h \
-	src/widgets/valueedit.h \
-	src/widgets/xmlcheck.h \
-	src/ui/about_dialog.h \
-	src/ui/checkablemessagebox.h \
-	src/ui/settingsdialog.h \
-	src/version.h \
-	lib/half.h \
-	lib/dds.h \
-	src/gl/bsshape.h \
-	src/material.h
+        src/qhull.h \
+        src/settings.h \
+        src/spellbook.h \
+        src/spells/blocks.h \
+        src/spells/mesh.h \
+        src/spells/misc.h \
+        src/spells/skeleton.h \
+        src/spells/stringpalette.h \
+        src/spells/tangentspace.h \
+        src/spells/texture.h \
+        src/spells/transform.h \
+        src/widgets/colorwheel.h \
+        src/widgets/fileselect.h \
+        src/widgets/floatedit.h \
+        src/widgets/floatslider.h \
+        src/widgets/groupbox.h \
+        src/widgets/inspect.h \
+        src/widgets/nifcheckboxlist.h \
+        src/widgets/nifeditors.h \
+        src/widgets/nifview.h \
+        src/widgets/refrbrowser.h \
+        src/widgets/uvedit.h \
+        src/widgets/valueedit.h \
+        src/widgets/xmlcheck.h \
+        src/ui/about_dialog.h \
+        src/ui/checkablemessagebox.h \
+        src/ui/settingsdialog.h \
+        src/version.h \
+        lib/half.h \
+        lib/dds.h \
+        lib/dxgiformat.h \
+        src/gl/bsshape.h \
+        src/material.h
 
 SOURCES += \
-	src/basemodel.cpp \
-	src/gl/dds/BlockDXT.cpp \
-	src/gl/dds/ColorBlock.cpp \
-	src/gl/dds/dds_api.cpp \
-	src/gl/dds/DirectDrawSurface.cpp \
-	src/gl/dds/Image.cpp \
-	src/gl/dds/Stream.cpp \
-	src/gl/controllers.cpp \
-	src/gl/glcontroller.cpp \
-	src/gl/glmarker.cpp \
-	src/gl/glmesh.cpp \
-	src/gl/glnode.cpp \
-	src/gl/glparticles.cpp \
-	src/gl/glproperty.cpp \
-	src/gl/glscene.cpp \
-	src/gl/gltex.cpp \
-	src/gl/gltexloaders.cpp \
-	src/gl/gltools.cpp \
-	src/gl/renderer.cpp \
-	src/glview.cpp \
-	src/importex/3ds.cpp \
-	src/importex/importex.cpp \
-	src/importex/obj.cpp \
-	src/importex/col.cpp \
-	src/kfmmodel.cpp \
-	src/kfmxml.cpp \
-	src/message.cpp \
-	src/nifdelegate.cpp \
-	src/nifexpr.cpp \
-	src/nifmodel.cpp \
-	src/nifproxy.cpp \
-	src/nifskope.cpp \
-	src/nifskope_ui.cpp \
-	src/niftypes.cpp \
-	src/nifvalue.cpp \
-	src/nifxml.cpp \
+        src/basemodel.cpp \
+        src/gl/dds/BlockDXT.cpp \
+        src/gl/dds/ColorBlock.cpp \
+        src/gl/dds/dds_api.cpp \
+        src/gl/dds/DirectDrawSurface.cpp \
+        src/gl/dds/Image.cpp \
+        src/gl/dds/Stream.cpp \
+        src/gl/controllers.cpp \
+        src/gl/glcontroller.cpp \
+        src/gl/glmarker.cpp \
+        src/gl/glmesh.cpp \
+        src/gl/glnode.cpp \
+        src/gl/glparticles.cpp \
+        src/gl/glproperty.cpp \
+        src/gl/glscene.cpp \
+        src/gl/gltex.cpp \
+        src/gl/gltexloaders.cpp \
+        src/gl/gltools.cpp \
+        src/gl/renderer.cpp \
+        src/glview.cpp \
+        src/importex/3ds.cpp \
+        src/importex/importex.cpp \
+        src/importex/obj.cpp \
+        src/importex/col.cpp \
+        src/kfmmodel.cpp \
+        src/kfmxml.cpp \
+        src/message.cpp \
+        src/nifdelegate.cpp \
+        src/nifexpr.cpp \
+        src/nifmodel.cpp \
+        src/nifproxy.cpp \
+        src/nifskope.cpp \
+        src/nifskope_ui.cpp \
+        src/niftypes.cpp \
+        src/nifvalue.cpp \
+        src/nifxml.cpp \
     src/nvtristripwrapper.cpp \
-	src/qhull.cpp \
-	src/settings.cpp \
-	src/spellbook.cpp \
-	src/spells/animation.cpp \
-	src/spells/blocks.cpp \
-	src/spells/bounds.cpp \
-	src/spells/color.cpp \
-	src/spells/flags.cpp \
-	src/spells/fo3only.cpp \
-	src/spells/havok.cpp \
-	src/spells/headerstring.cpp \
-	src/spells/light.cpp \
-	src/spells/materialedit.cpp \
-	src/spells/mesh.cpp \
-	src/spells/misc.cpp \
-	src/spells/moppcode.cpp \
-	src/spells/morphctrl.cpp \
-	src/spells/normals.cpp \
-	src/spells/optimize.cpp \
-	src/spells/sanitize.cpp \
-	src/spells/skeleton.cpp \
-	src/spells/stringpalette.cpp \
-	src/spells/strippify.cpp \
-	src/spells/tangentspace.cpp \
-	src/spells/texture.cpp \
-	src/spells/transform.cpp \
-	src/widgets/colorwheel.cpp \
-	src/widgets/fileselect.cpp \
-	src/widgets/floatedit.cpp \
-	src/widgets/floatslider.cpp \
-	src/widgets/groupbox.cpp \
-	src/widgets/inspect.cpp \
-	src/widgets/nifcheckboxlist.cpp \
-	src/widgets/nifeditors.cpp \
-	src/widgets/nifview.cpp \
-	src/widgets/refrbrowser.cpp \
-	src/widgets/uvedit.cpp \
-	src/widgets/valueedit.cpp \
-	src/widgets/xmlcheck.cpp \
-	src/ui/about_dialog.cpp \
-	src/ui/checkablemessagebox.cpp \
-	src/ui/settingsdialog.cpp \
-	src/version.cpp \
-	lib/half.cpp \
-	src/gl/bsshape.cpp \
-	src/material.cpp
+        src/qhull.cpp \
+        src/settings.cpp \
+        src/spellbook.cpp \
+        src/spells/animation.cpp \
+        src/spells/blocks.cpp \
+        src/spells/bounds.cpp \
+        src/spells/color.cpp \
+        src/spells/flags.cpp \
+        src/spells/fo3only.cpp \
+        src/spells/havok.cpp \
+        src/spells/headerstring.cpp \
+        src/spells/light.cpp \
+        src/spells/materialedit.cpp \
+        src/spells/mesh.cpp \
+        src/spells/misc.cpp \
+        src/spells/moppcode.cpp \
+        src/spells/morphctrl.cpp \
+        src/spells/normals.cpp \
+        src/spells/optimize.cpp \
+        src/spells/sanitize.cpp \
+        src/spells/skeleton.cpp \
+        src/spells/stringpalette.cpp \
+        src/spells/strippify.cpp \
+        src/spells/tangentspace.cpp \
+        src/spells/texture.cpp \
+        src/spells/transform.cpp \
+        src/widgets/colorwheel.cpp \
+        src/widgets/fileselect.cpp \
+        src/widgets/floatedit.cpp \
+        src/widgets/floatslider.cpp \
+        src/widgets/groupbox.cpp \
+        src/widgets/inspect.cpp \
+        src/widgets/nifcheckboxlist.cpp \
+        src/widgets/nifeditors.cpp \
+        src/widgets/nifview.cpp \
+        src/widgets/refrbrowser.cpp \
+        src/widgets/uvedit.cpp \
+        src/widgets/valueedit.cpp \
+        src/widgets/xmlcheck.cpp \
+        src/ui/about_dialog.cpp \
+        src/ui/checkablemessagebox.cpp \
+        src/ui/settingsdialog.cpp \
+        src/version.cpp \
+        lib/half.cpp \
+        src/gl/bsshape.cpp \
+        src/material.cpp
 
 RESOURCES += \
-	res/nifskope.qrc
+        res/nifskope.qrc
 
 FORMS += \
-	src/ui/about_dialog.ui \
-	src/ui/checkablemessagebox.ui \
-	src/ui/nifskope.ui \
-	src/ui/settingsdialog.ui \
+        src/ui/about_dialog.ui \
+        src/ui/checkablemessagebox.ui \
+        src/ui/nifskope.ui \
+        src/ui/settingsdialog.ui \
     src/ui/settingsgeneral.ui \
     src/ui/settingsrender.ui \
     src/ui/settingsresources.ui
@@ -313,43 +313,43 @@ FORMS += \
 ###############################
 
 fsengine {
-	INCLUDEPATH += lib/fsengine
-	HEADERS += \
-		lib/fsengine/bsa.h \
-		lib/fsengine/fsengine.h \
-		lib/fsengine/fsmanager.h
-	SOURCES += \
-		lib/fsengine/bsa.cpp \
-		lib/fsengine/fsengine.cpp \
-		lib/fsengine/fsmanager.cpp
+        INCLUDEPATH += lib/fsengine
+        HEADERS += \
+                lib/fsengine/bsa.h \
+                lib/fsengine/fsengine.h \
+                lib/fsengine/fsmanager.h
+        SOURCES += \
+                lib/fsengine/bsa.cpp \
+                lib/fsengine/fsengine.cpp \
+                lib/fsengine/fsmanager.cpp
 }
 
 nvtristrip {
-	INCLUDEPATH += lib/NvTriStrip
-	HEADERS += \
-		lib/NvTriStrip/NvTriStrip.h \
-		lib/NvTriStrip/NvTriStripObjects.h \
-		lib/NvTriStrip/VertexCache.h
-	SOURCES += \
-		lib/NvTriStrip/NvTriStrip.cpp \
-		lib/NvTriStrip/NvTriStripObjects.cpp \
-		lib/NvTriStrip/VertexCache.cpp
+        INCLUDEPATH += lib/NvTriStrip
+        HEADERS += \
+                lib/NvTriStrip/NvTriStrip.h \
+                lib/NvTriStrip/NvTriStripObjects.h \
+                lib/NvTriStrip/VertexCache.h
+        SOURCES += \
+                lib/NvTriStrip/NvTriStrip.cpp \
+                lib/NvTriStrip/NvTriStripObjects.cpp \
+                lib/NvTriStrip/VertexCache.cpp
 }
 
 qhull {
-	INCLUDEPATH += lib/qhull/src
-	HEADERS += \
-		lib/qhull/src/libqhull/geom.h \
-		lib/qhull/src/libqhull/io.h \
-		lib/qhull/src/libqhull/libqhull.h \
-		lib/qhull/src/libqhull/mem.h \
-		lib/qhull/src/libqhull/merge.h \
-		lib/qhull/src/libqhull/poly.h \
-		lib/qhull/src/libqhull/qhull_a.h \
-		lib/qhull/src/libqhull/qset.h \
-		lib/qhull/src/libqhull/random.h \
-		lib/qhull/src/libqhull/stat.h \
-		lib/qhull/src/libqhull/user.h
+        INCLUDEPATH += lib/qhull/src
+        HEADERS += \
+                lib/qhull/src/libqhull/geom.h \
+                lib/qhull/src/libqhull/io.h \
+                lib/qhull/src/libqhull/libqhull.h \
+                lib/qhull/src/libqhull/mem.h \
+                lib/qhull/src/libqhull/merge.h \
+                lib/qhull/src/libqhull/poly.h \
+                lib/qhull/src/libqhull/qhull_a.h \
+                lib/qhull/src/libqhull/qset.h \
+                lib/qhull/src/libqhull/random.h \
+                lib/qhull/src/libqhull/stat.h \
+                lib/qhull/src/libqhull/user.h
 }
 
 soil {
@@ -369,37 +369,37 @@ soil {
 }
 
 zlib {
-	INCLUDEPATH += lib/zlib
+        INCLUDEPATH += lib/zlib
 
-	HEADERS += \
-		lib/zlib/crc32.h \
-		lib/zlib/deflate.h \
-		lib/zlib/gzguts.h \
-		lib/zlib/inffast.h \
-		lib/zlib/inffixed.h \
-		lib/zlib/inflate.h \
-		lib/zlib/inftrees.h \
-		lib/zlib/trees.h \
-		lib/zlib/zconf.h \
-		lib/zlib/zlib.h \
-		lib/zlib/zutil.h
+        HEADERS += \
+                lib/zlib/crc32.h \
+                lib/zlib/deflate.h \
+                lib/zlib/gzguts.h \
+                lib/zlib/inffast.h \
+                lib/zlib/inffixed.h \
+                lib/zlib/inflate.h \
+                lib/zlib/inftrees.h \
+                lib/zlib/trees.h \
+                lib/zlib/zconf.h \
+                lib/zlib/zlib.h \
+                lib/zlib/zutil.h
 
-	SOURCES += \
-		lib/zlib/adler32.c \
-		lib/zlib/compress.c \
-		lib/zlib/crc32.c \
-		lib/zlib/deflate.c \
-		lib/zlib/gzclose.c \
-		lib/zlib/gzlib.c \
-		lib/zlib/gzread.c \
-		lib/zlib/gzwrite.c \
-		lib/zlib/infback.c \
-		lib/zlib/inffast.c \
-		lib/zlib/inflate.c \
-		lib/zlib/inftrees.c \
-		lib/zlib/trees.c \
-		lib/zlib/uncompr.c \
-		lib/zlib/zutil.c
+        SOURCES += \
+                lib/zlib/adler32.c \
+                lib/zlib/compress.c \
+                lib/zlib/crc32.c \
+                lib/zlib/deflate.c \
+                lib/zlib/gzclose.c \
+                lib/zlib/gzlib.c \
+                lib/zlib/gzread.c \
+                lib/zlib/gzwrite.c \
+                lib/zlib/infback.c \
+                lib/zlib/inffast.c \
+                lib/zlib/inflate.c \
+                lib/zlib/inftrees.c \
+                lib/zlib/trees.c \
+                lib/zlib/uncompr.c \
+                lib/zlib/zutil.c
 }
 
 lz4 {
@@ -423,8 +423,8 @@ QMAKE_CXXFLAGS_RELEASE -= -O1
 QMAKE_CXXFLAGS_RELEASE -= -O2
 
 win32 {
-	RC_FILE = res/icon.rc
-	DEFINES += EDIT_ON_ACTIVATE
+        RC_FILE = res/icon.rc
+        DEFINES += EDIT_ON_ACTIVATE
 }
 
 # MSVC
@@ -432,38 +432,38 @@ win32 {
 #  Required: msvc2013 or higher
 *msvc* {
 
-	# Grab _MSC_VER from the mkspecs that Qt was compiled with
-	#	e.g. VS2013 = 1800, VS2012 = 1700, VS2010 = 1600
-	_MSC_VER = $$find(QMAKE_COMPILER_DEFINES, "_MSC_VER")
-	_MSC_VER = $$split(_MSC_VER, =)
-	_MSC_VER = $$member(_MSC_VER, 1)
+        # Grab _MSC_VER from the mkspecs that Qt was compiled with
+        #	e.g. VS2013 = 1800, VS2012 = 1700, VS2010 = 1600
+        _MSC_VER = $$find(QMAKE_COMPILER_DEFINES, "_MSC_VER")
+        _MSC_VER = $$split(_MSC_VER, =)
+        _MSC_VER = $$member(_MSC_VER, 1)
 
-	# Reject unsupported MSVC versions
-	!isEmpty(_MSC_VER):lessThan(_MSC_VER, 1800) {
-		error("NifSkope only supports MSVC 2013 or later. If this is too prohibitive you may use Qt Creator with MinGW.")
-	}
+        # Reject unsupported MSVC versions
+        !isEmpty(_MSC_VER):lessThan(_MSC_VER, 1800) {
+                error("NifSkope only supports MSVC 2013 or later. If this is too prohibitive you may use Qt Creator with MinGW.")
+        }
 
-	# So VCProj Filters do not flatten headers/source
-	CONFIG -= flat
+        # So VCProj Filters do not flatten headers/source
+        CONFIG -= flat
 
-	# COMPILER FLAGS
+        # COMPILER FLAGS
 
-	#  Optimization flags
-	QMAKE_CXXFLAGS_RELEASE *= -O2 -arch:SSE2 # SSE2 is the default, but make it explicit
-	#  Multithreaded compiling for Visual Studio
-	QMAKE_CXXFLAGS += -MP
+        #  Optimization flags
+        QMAKE_CXXFLAGS_RELEASE *= -O2 -arch:SSE2 # SSE2 is the default, but make it explicit
+        #  Multithreaded compiling for Visual Studio
+        QMAKE_CXXFLAGS += -MP
 
-	# LINKER FLAGS
+        # LINKER FLAGS
 
-	#  Relocate .lib and .exp files to keep release dir clean
-	QMAKE_LFLAGS += /IMPLIB:$$syspath($${INTERMEDIATE}/NifSkope.lib)
+        #  Relocate .lib and .exp files to keep release dir clean
+        QMAKE_LFLAGS += /IMPLIB:$$syspath($${INTERMEDIATE}/NifSkope.lib)
 
-	#  PDB location
-	QMAKE_LFLAGS_DEBUG += /PDB:$$syspath($${INTERMEDIATE}/nifskope.pdb)
+        #  PDB location
+        QMAKE_LFLAGS_DEBUG += /PDB:$$syspath($${INTERMEDIATE}/nifskope.pdb)
 
-	#  Clean up .embed.manifest from release dir
-	#	Fallback for `Manifest Embed` above
-	QMAKE_POST_LINK += $$QMAKE_DEL_FILE $$syspath($${DESTDIR}/*.manifest) $$nt
+        #  Clean up .embed.manifest from release dir
+        #	Fallback for `Manifest Embed` above
+        QMAKE_POST_LINK += $$QMAKE_DEL_FILE $$syspath($${DESTDIR}/*.manifest) $$nt
 }
 
 
@@ -471,18 +471,18 @@ win32 {
 #  Recommended: GCC 4.8.1+
 *-g++ {
 
-	# COMPILER FLAGS
+        # COMPILER FLAGS
 
-	#  Optimization flags
-	QMAKE_CXXFLAGS_DEBUG -= -O0 -g
-	QMAKE_CXXFLAGS_DEBUG *= -Og -g3
-	QMAKE_CXXFLAGS_RELEASE *= -O3 -mfpmath=sse
+        #  Optimization flags
+        QMAKE_CXXFLAGS_DEBUG -= -O0 -g
+        QMAKE_CXXFLAGS_DEBUG *= -Og -g3
+        QMAKE_CXXFLAGS_RELEASE *= -O3 -mfpmath=sse
 
-	# C++11 Support
-	QMAKE_CXXFLAGS_RELEASE *= -std=c++11
+        # C++11 Support
+        QMAKE_CXXFLAGS_RELEASE *= -std=c++11
 
-	#  Extension flags
-	QMAKE_CXXFLAGS_RELEASE *= -msse2 -msse
+        #  Extension flags
+        QMAKE_CXXFLAGS_RELEASE *= -msse2 -msse
 }
 
 win32 {
@@ -491,11 +491,11 @@ win32 {
 }
 
 unix:!macx {
-	LIBS += -lGLU
+        LIBS += -lGLU
 }
 
 macx {
-	LIBS += -framework CoreFoundation
+        LIBS += -framework CoreFoundation
 }
 
 
@@ -506,75 +506,75 @@ build_pass|!debug_and_release {
 ## QMAKE_PRE_LINK
 ###############################
 
-	# Find `sed` command
-	SED = $$getSed()
+        # Find `sed` command
+        SED = $$getSed()
 
-	!isEmpty(SED) {
-		# Replace @VERSION@ with number from build/VERSION
-		# Copy build/README.md.in > README.md
-		QMAKE_PRE_LINK += $${SED} -e s/@VERSION@/$${VER}/ $${PWD}/build/README.md.in > $${PWD}/README.md $$nt
-	}
+        !isEmpty(SED) {
+                # Replace @VERSION@ with number from build/VERSION
+                # Copy build/README.md.in > README.md
+                QMAKE_PRE_LINK += $${SED} -e s/@VERSION@/$${VER}/ $${PWD}/build/README.md.in > $${PWD}/README.md $$nt
+        }
 
 
 ###############################
 ## QMAKE_POST_LINK
 ###############################
 
-	win32:DEP += \
-		dep/NifMopp.dll
+        win32:DEP += \
+                dep/NifMopp.dll
 
-	XML += \
-		build/docsys/nifxml/nif.xml \
-		build/docsys/kfmxml/kfm.xml
+        XML += \
+                build/docsys/nifxml/nif.xml \
+                build/docsys/kfmxml/kfm.xml
 
-	QSS += \
-		res/style.qss
+        QSS += \
+                res/style.qss
 
-	QHULLTXT += \
-		lib/qhull/COPYING.txt
+        QHULLTXT += \
+                lib/qhull/COPYING.txt
 
-	#LANG += \
-	#	res/lang
+        #LANG += \
+        #	res/lang
 
-	SHADERS += \
-		res/shaders
+        SHADERS += \
+                res/shaders
 
-	READMES += \
-		CHANGELOG.md \
-		CONTRIBUTORS.md \
-		LICENSE.md \
-		README.md \
-		TROUBLESHOOTING.md
+        READMES += \
+                CHANGELOG.md \
+                CONTRIBUTORS.md \
+                LICENSE.md \
+                README.md \
+                TROUBLESHOOTING.md
 
 
-	copyDirs( $$SHADERS, shaders )
-	#copyDirs( $$LANG, lang )
+        copyDirs( $$SHADERS, shaders )
+        #copyDirs( $$LANG, lang )
     #copyFiles( $$XML $$QSS )
-	win32:copyFiles( $$DEP )
+        win32:copyFiles( $$DEP )
 
-	# Copy Readmes and rename to TXT
-	copyFiles( $$READMES,,,, md:txt )
+        # Copy Readmes and rename to TXT
+        copyFiles( $$READMES,,,, md:txt )
 
-	# Copy Qhull COPYING.TXT and rename
-	copyFiles( $$QHULLTXT,,, Qhull_COPYING.txt )
+        # Copy Qhull COPYING.TXT and rename
+        copyFiles( $$QHULLTXT,,, Qhull_COPYING.txt )
 
-	win32:!static {
-		# Copy DLLs to build dir
-		copyFiles( $$QtBins(),, true )
+        win32:!static {
+                # Copy DLLs to build dir
+                copyFiles( $$QtBins(),, true )
 
-		platforms += \
-			$$[QT_INSTALL_PLUGINS]/platforms/qminimal$${DLLEXT} \
-			$$[QT_INSTALL_PLUGINS]/platforms/qwindows$${DLLEXT}
-		
-		imageformats += \
-			$$[QT_INSTALL_PLUGINS]/imageformats/qdds$${DLLEXT} \
-			$$[QT_INSTALL_PLUGINS]/imageformats/qjpeg$${DLLEXT} \
-			$$[QT_INSTALL_PLUGINS]/imageformats/qtga$${DLLEXT} \
-			$$[QT_INSTALL_PLUGINS]/imageformats/qwebp$${DLLEXT}
+                platforms += \
+                        $$[QT_INSTALL_PLUGINS]/platforms/qminimal$${DLLEXT} \
+                        $$[QT_INSTALL_PLUGINS]/platforms/qwindows$${DLLEXT}
 
-		copyFiles( $$platforms, platforms, true )
-		copyFiles( $$imageformats, imageformats, true )
-	}
+                imageformats += \
+                        $$[QT_INSTALL_PLUGINS]/imageformats/qdds$${DLLEXT} \
+                        $$[QT_INSTALL_PLUGINS]/imageformats/qjpeg$${DLLEXT} \
+                        $$[QT_INSTALL_PLUGINS]/imageformats/qtga$${DLLEXT} \
+                        $$[QT_INSTALL_PLUGINS]/imageformats/qwebp$${DLLEXT}
+
+                copyFiles( $$platforms, platforms, true )
+                copyFiles( $$imageformats, imageformats, true )
+        }
 
 } # end build_pass
 
@@ -582,24 +582,24 @@ build_pass|!debug_and_release {
 # Build Messages
 # (Add `buildMessages` to CONFIG to use)
 buildMessages:build_pass|buildMessages:!debug_and_release {
-	CONFIG(debug, debug|release) {
-		message("Debug Mode")
-	} CONFIG(release, release|debug) {
-		message("Release Mode")
-	}
+        CONFIG(debug, debug|release) {
+                message("Debug Mode")
+        } CONFIG(release, release|debug) {
+                message("Release Mode")
+        }
 
-	message(mkspec _______ $$QMAKESPEC)
-	message(cxxflags _____ $$QMAKE_CXXFLAGS)
-	message(arch _________ $$QMAKE_TARGET.arch)
-	message(src __________ $$PWD)
-	message(build ________ $$OUT_PWD)
-	message(Qt binaries __ $$[QT_INSTALL_BINS])
+        message(mkspec _______ $$QMAKESPEC)
+        message(cxxflags _____ $$QMAKE_CXXFLAGS)
+        message(arch _________ $$QMAKE_TARGET.arch)
+        message(src __________ $$PWD)
+        message(build ________ $$OUT_PWD)
+        message(Qt binaries __ $$[QT_INSTALL_BINS])
 
-	build_pass:equals( VISUALSTUDIO, true ) {
-		message(Visual Studio __ Yes)
-	}
+        build_pass:equals( VISUALSTUDIO, true ) {
+                message(Visual Studio __ Yes)
+        }
 
-	#message($$CONFIG)
+        #message($$CONFIG)
 }
 
-# vim: set filetype=config : 
+# vim: set filetype=config :

--- a/NifSkope.pro
+++ b/NifSkope.pro
@@ -9,26 +9,27 @@ QT += xml opengl network widgets
 
 # Require Qt 5.5 or higher
 contains(QT_VERSION, ^5\\.[0-4]\\..*) {
-        message("Cannot build NifSkope with Qt version $${QT_VERSION}")
-        error("Minimum required version is Qt 5.5")
+	message("Cannot build NifSkope with Qt version $${QT_VERSION}")
+	error("Minimum required version is Qt 5.5")
 }
 
 # C++11 Support
 CONFIG += c++11
 
 # Dependencies
-CONFIG += nvtristrip qhull soil zlib lz4 fsengine
+CONFIG += nvtristrip qhull soil zlib lz4
+win32:CONFIG += fsengine
 
 # Debug/Release options
 CONFIG(debug, debug|release) {
-        # Debug Options
-        BUILD = debug
-        CONFIG += console
+	# Debug Options
+	BUILD = debug
+	CONFIG += console
 } else {
-        # Release Options
-        BUILD = release
-        CONFIG -= console
-        DEFINES += QT_NO_DEBUG_OUTPUT
+	# Release Options
+	BUILD = release
+	CONFIG -= console
+	DEFINES += QT_NO_DEBUG_OUTPUT
 }
 # TODO: Get rid of this define
 #	uncomment this if you want the text stats gl option
@@ -37,43 +38,43 @@ CONFIG(debug, debug|release) {
 INCLUDEPATH += src lib
 
 TRANSLATIONS += \
-        res/lang/NifSkope_de.ts \
-        res/lang/NifSkope_fr.ts
+	res/lang/NifSkope_de.ts \
+	res/lang/NifSkope_fr.ts
 
 # Require explicit
 DEFINES += \
-        QT_NO_CAST_FROM_BYTEARRAY \ # QByteArray deprecations
-        QT_NO_URL_CAST_FROM_STRING \ # QUrl deprecations
-        QT_DISABLE_DEPRECATED_BEFORE=0x050300 #\ # Disable all functions deprecated as of 5.3
+	QT_NO_CAST_FROM_BYTEARRAY \ # QByteArray deprecations
+	QT_NO_URL_CAST_FROM_STRING \ # QUrl deprecations
+	QT_DISABLE_DEPRECATED_BEFORE=0x050300 #\ # Disable all functions deprecated as of 5.3
 
-        # Useful for tracking down strings not using
-        #	QObject::tr() for translations.
-        # QT_NO_CAST_FROM_ASCII \
-        # QT_NO_CAST_TO_ASCII
+	# Useful for tracking down strings not using
+	#	QObject::tr() for translations.
+	# QT_NO_CAST_FROM_ASCII \
+	# QT_NO_CAST_TO_ASCII
 
 
 VISUALSTUDIO = false
 *msvc* {
-        ######################################
-        ## Detect Visual Studio vs Qt Creator
-        ######################################
-        #	Qt Creator = shadow build
-        #	Visual Studio = no shadow build
+	######################################
+	## Detect Visual Studio vs Qt Creator
+	######################################
+	#	Qt Creator = shadow build
+	#	Visual Studio = no shadow build
 
-        # Strips PWD (source) from OUT_PWD (build) to test if they are on the same path
-        #	- contains() does not work
-        #	- equals( PWD, $${OUT_PWD} ) is not sufficient
-        REP = $$replace(OUT_PWD, $${PWD}, "")
+	# Strips PWD (source) from OUT_PWD (build) to test if they are on the same path
+	#	- contains() does not work
+	#	- equals( PWD, $${OUT_PWD} ) is not sufficient
+	REP = $$replace(OUT_PWD, $${PWD}, "")
 
-        # Test if Build dir is outside Source dir
-        #	if REP == OUT_PWD, not Visual Studio
-        !equals( REP, $${OUT_PWD} ):VISUALSTUDIO = true
-        unset(REP)
+	# Test if Build dir is outside Source dir
+	#	if REP == OUT_PWD, not Visual Studio
+	!equals( REP, $${OUT_PWD} ):VISUALSTUDIO = true
+	unset(REP)
 
-        # Set OUT_PWD to ./bin so that qmake doesn't clutter PWD
-        #	Unfortunately w/ VS qmake still creates empty debug/release folders in PWD.
-        #	They are never used but get auto-generated because of CONFIG += debug_and_release
-        $$VISUALSTUDIO:OUT_PWD = $${_PRO_FILE_PWD_}/bin
+	# Set OUT_PWD to ./bin so that qmake doesn't clutter PWD
+	#	Unfortunately w/ VS qmake still creates empty debug/release folders in PWD.
+	#	They are never used but get auto-generated because of CONFIG += debug_and_release
+	$$VISUALSTUDIO:OUT_PWD = $${_PRO_FILE_PWD_}/bin
 }
 
 ###############################
@@ -97,7 +98,7 @@ DEFINES += NIFSKOPE_VERSION=\\\"$${VER}\\\"
 
 # NIFSKOPE_REVISION macro
 !isEmpty(REVISION) {
-        DEFINES += NIFSKOPE_REVISION=\\\"$${REVISION}\\\"
+	DEFINES += NIFSKOPE_REVISION=\\\"$${REVISION}\\\"
 }
 
 
@@ -108,22 +109,22 @@ DEFINES += NIFSKOPE_VERSION=\\\"$${VER}\\\"
 # build_pass is necessary
 # Otherwise it will create empty .moc, .ui, etc. dirs on the drive root
 build_pass|!debug_and_release {
-        win32:equals( VISUALSTUDIO, true ) {
-                # Visual Studio
-                DESTDIR = $${_PRO_FILE_PWD_}/bin/$${BUILD}
-                # INTERMEDIATE FILES
-                INTERMEDIATE = $${DESTDIR}/../GeneratedFiles/$${BUILD}
-        } else {
-                # Qt Creator
-                DESTDIR = $${OUT_PWD}/$${BUILD}
-                # INTERMEDIATE FILES
-                INTERMEDIATE = $${DESTDIR}/../GeneratedFiles/
-        }
+	win32:equals( VISUALSTUDIO, true ) {
+		# Visual Studio
+		DESTDIR = $${_PRO_FILE_PWD_}/bin/$${BUILD}
+		# INTERMEDIATE FILES
+		INTERMEDIATE = $${DESTDIR}/../GeneratedFiles/$${BUILD}
+	} else {
+		# Qt Creator
+		DESTDIR = $${OUT_PWD}/$${BUILD}
+		# INTERMEDIATE FILES
+		INTERMEDIATE = $${DESTDIR}/../GeneratedFiles/
+	}
 
-        UI_DIR = $${INTERMEDIATE}/.ui
-        MOC_DIR = $${INTERMEDIATE}/.moc
-        RCC_DIR = $${INTERMEDIATE}/.qrc
-        OBJECTS_DIR = $${INTERMEDIATE}/.obj
+	UI_DIR = $${INTERMEDIATE}/.ui
+	MOC_DIR = $${INTERMEDIATE}/.moc
+	RCC_DIR = $${INTERMEDIATE}/.qrc
+	OBJECTS_DIR = $${INTERMEDIATE}/.obj
 }
 
 ###############################
@@ -138,171 +139,171 @@ include(NifSkope_targets.pri)
 ###############################
 
 HEADERS += \
-        src/basemodel.h \
-        src/config.h \
-        src/gl/dds/BlockDXT.h \
-        src/gl/dds/Color.h \
-        src/gl/dds/ColorBlock.h \
-        src/gl/dds/Common.h \
-        src/gl/dds/dds_api.h \
-        src/gl/dds/DirectDrawSurface.h \
-        src/gl/dds/Image.h \
-        src/gl/dds/PixelFormat.h \
-        src/gl/dds/Stream.h \
-        src/gl/controllers.h \
-        src/gl/glcontroller.h \
-        src/gl/glmarker.h \
-        src/gl/glmesh.h \
-        src/gl/glnode.h \
-        src/gl/glparticles.h \
-        src/gl/glproperty.h \
-        src/gl/glscene.h \
-        src/gl/gltex.h \
-        src/gl/gltexloaders.h \
-        src/gl/gltools.h \
-        src/gl/icontrollable.h \
-        src/gl/marker/constraints.h \
-        src/gl/marker/furniture.h \
-        src/gl/renderer.h \
-        src/glview.h \
-        src/importex/3ds.h \
-        src/kfmmodel.h \
-        src/message.h \
-        src/nifexpr.h \
-        src/nifitem.h \
-        src/nifmodel.h \
-        src/nifproxy.h \
-        src/nifskope.h \
-        src/niftypes.h \
-        src/nifvalue.h \
+	src/basemodel.h \
+	src/config.h \
+	src/gl/dds/BlockDXT.h \
+	src/gl/dds/Color.h \
+	src/gl/dds/ColorBlock.h \
+	src/gl/dds/Common.h \
+	src/gl/dds/dds_api.h \
+	src/gl/dds/DirectDrawSurface.h \
+	src/gl/dds/Image.h \
+	src/gl/dds/PixelFormat.h \
+	src/gl/dds/Stream.h \
+	src/gl/controllers.h \
+	src/gl/glcontroller.h \
+	src/gl/glmarker.h \
+	src/gl/glmesh.h \
+	src/gl/glnode.h \
+	src/gl/glparticles.h \
+	src/gl/glproperty.h \
+	src/gl/glscene.h \
+	src/gl/gltex.h \
+	src/gl/gltexloaders.h \
+	src/gl/gltools.h \
+	src/gl/icontrollable.h \
+	src/gl/marker/constraints.h \
+	src/gl/marker/furniture.h \
+	src/gl/renderer.h \
+	src/glview.h \
+	src/importex/3ds.h \
+	src/kfmmodel.h \
+	src/message.h \
+	src/nifexpr.h \
+	src/nifitem.h \
+	src/nifmodel.h \
+	src/nifproxy.h \
+	src/nifskope.h \
+	src/niftypes.h \
+	src/nifvalue.h \
     src/nvtristripwrapper.h \
-        src/qhull.h \
-        src/settings.h \
-        src/spellbook.h \
-        src/spells/blocks.h \
-        src/spells/mesh.h \
-        src/spells/misc.h \
-        src/spells/skeleton.h \
-        src/spells/stringpalette.h \
-        src/spells/tangentspace.h \
-        src/spells/texture.h \
-        src/spells/transform.h \
-        src/widgets/colorwheel.h \
-        src/widgets/fileselect.h \
-        src/widgets/floatedit.h \
-        src/widgets/floatslider.h \
-        src/widgets/groupbox.h \
-        src/widgets/inspect.h \
-        src/widgets/nifcheckboxlist.h \
-        src/widgets/nifeditors.h \
-        src/widgets/nifview.h \
-        src/widgets/refrbrowser.h \
-        src/widgets/uvedit.h \
-        src/widgets/valueedit.h \
-        src/widgets/xmlcheck.h \
-        src/ui/about_dialog.h \
-        src/ui/checkablemessagebox.h \
-        src/ui/settingsdialog.h \
-        src/version.h \
-        lib/half.h \
-        lib/dds.h \
-        lib/dxgiformat.h \
-        src/gl/bsshape.h \
-        src/material.h
+	src/qhull.h \
+	src/settings.h \
+	src/spellbook.h \
+	src/spells/blocks.h \
+	src/spells/mesh.h \
+	src/spells/misc.h \
+	src/spells/skeleton.h \
+	src/spells/stringpalette.h \
+	src/spells/tangentspace.h \
+	src/spells/texture.h \
+	src/spells/transform.h \
+	src/widgets/colorwheel.h \
+	src/widgets/fileselect.h \
+	src/widgets/floatedit.h \
+	src/widgets/floatslider.h \
+	src/widgets/groupbox.h \
+	src/widgets/inspect.h \
+	src/widgets/nifcheckboxlist.h \
+	src/widgets/nifeditors.h \
+	src/widgets/nifview.h \
+	src/widgets/refrbrowser.h \
+	src/widgets/uvedit.h \
+	src/widgets/valueedit.h \
+	src/widgets/xmlcheck.h \
+	src/ui/about_dialog.h \
+	src/ui/checkablemessagebox.h \
+	src/ui/settingsdialog.h \
+	src/version.h \
+	lib/half.h \
+	lib/dds.h \
+	lib/dxgiformat.h \
+	src/gl/bsshape.h \
+	src/material.h
 
 SOURCES += \
-        src/basemodel.cpp \
-        src/gl/dds/BlockDXT.cpp \
-        src/gl/dds/ColorBlock.cpp \
-        src/gl/dds/dds_api.cpp \
-        src/gl/dds/DirectDrawSurface.cpp \
-        src/gl/dds/Image.cpp \
-        src/gl/dds/Stream.cpp \
-        src/gl/controllers.cpp \
-        src/gl/glcontroller.cpp \
-        src/gl/glmarker.cpp \
-        src/gl/glmesh.cpp \
-        src/gl/glnode.cpp \
-        src/gl/glparticles.cpp \
-        src/gl/glproperty.cpp \
-        src/gl/glscene.cpp \
-        src/gl/gltex.cpp \
-        src/gl/gltexloaders.cpp \
-        src/gl/gltools.cpp \
-        src/gl/renderer.cpp \
-        src/glview.cpp \
-        src/importex/3ds.cpp \
-        src/importex/importex.cpp \
-        src/importex/obj.cpp \
-        src/importex/col.cpp \
-        src/kfmmodel.cpp \
-        src/kfmxml.cpp \
-        src/message.cpp \
-        src/nifdelegate.cpp \
-        src/nifexpr.cpp \
-        src/nifmodel.cpp \
-        src/nifproxy.cpp \
-        src/nifskope.cpp \
-        src/nifskope_ui.cpp \
-        src/niftypes.cpp \
-        src/nifvalue.cpp \
-        src/nifxml.cpp \
+	src/basemodel.cpp \
+	src/gl/dds/BlockDXT.cpp \
+	src/gl/dds/ColorBlock.cpp \
+	src/gl/dds/dds_api.cpp \
+	src/gl/dds/DirectDrawSurface.cpp \
+	src/gl/dds/Image.cpp \
+	src/gl/dds/Stream.cpp \
+	src/gl/controllers.cpp \
+	src/gl/glcontroller.cpp \
+	src/gl/glmarker.cpp \
+	src/gl/glmesh.cpp \
+	src/gl/glnode.cpp \
+	src/gl/glparticles.cpp \
+	src/gl/glproperty.cpp \
+	src/gl/glscene.cpp \
+	src/gl/gltex.cpp \
+	src/gl/gltexloaders.cpp \
+	src/gl/gltools.cpp \
+	src/gl/renderer.cpp \
+	src/glview.cpp \
+	src/importex/3ds.cpp \
+	src/importex/importex.cpp \
+	src/importex/obj.cpp \
+	src/importex/col.cpp \
+	src/kfmmodel.cpp \
+	src/kfmxml.cpp \
+	src/message.cpp \
+	src/nifdelegate.cpp \
+	src/nifexpr.cpp \
+	src/nifmodel.cpp \
+	src/nifproxy.cpp \
+	src/nifskope.cpp \
+	src/nifskope_ui.cpp \
+	src/niftypes.cpp \
+	src/nifvalue.cpp \
+	src/nifxml.cpp \
     src/nvtristripwrapper.cpp \
-        src/qhull.cpp \
-        src/settings.cpp \
-        src/spellbook.cpp \
-        src/spells/animation.cpp \
-        src/spells/blocks.cpp \
-        src/spells/bounds.cpp \
-        src/spells/color.cpp \
-        src/spells/flags.cpp \
-        src/spells/fo3only.cpp \
-        src/spells/havok.cpp \
-        src/spells/headerstring.cpp \
-        src/spells/light.cpp \
-        src/spells/materialedit.cpp \
-        src/spells/mesh.cpp \
-        src/spells/misc.cpp \
-        src/spells/moppcode.cpp \
-        src/spells/morphctrl.cpp \
-        src/spells/normals.cpp \
-        src/spells/optimize.cpp \
-        src/spells/sanitize.cpp \
-        src/spells/skeleton.cpp \
-        src/spells/stringpalette.cpp \
-        src/spells/strippify.cpp \
-        src/spells/tangentspace.cpp \
-        src/spells/texture.cpp \
-        src/spells/transform.cpp \
-        src/widgets/colorwheel.cpp \
-        src/widgets/fileselect.cpp \
-        src/widgets/floatedit.cpp \
-        src/widgets/floatslider.cpp \
-        src/widgets/groupbox.cpp \
-        src/widgets/inspect.cpp \
-        src/widgets/nifcheckboxlist.cpp \
-        src/widgets/nifeditors.cpp \
-        src/widgets/nifview.cpp \
-        src/widgets/refrbrowser.cpp \
-        src/widgets/uvedit.cpp \
-        src/widgets/valueedit.cpp \
-        src/widgets/xmlcheck.cpp \
-        src/ui/about_dialog.cpp \
-        src/ui/checkablemessagebox.cpp \
-        src/ui/settingsdialog.cpp \
-        src/version.cpp \
-        lib/half.cpp \
-        src/gl/bsshape.cpp \
-        src/material.cpp
+	src/qhull.cpp \
+	src/settings.cpp \
+	src/spellbook.cpp \
+	src/spells/animation.cpp \
+	src/spells/blocks.cpp \
+	src/spells/bounds.cpp \
+	src/spells/color.cpp \
+	src/spells/flags.cpp \
+	src/spells/fo3only.cpp \
+	src/spells/havok.cpp \
+	src/spells/headerstring.cpp \
+	src/spells/light.cpp \
+	src/spells/materialedit.cpp \
+	src/spells/mesh.cpp \
+	src/spells/misc.cpp \
+	src/spells/moppcode.cpp \
+	src/spells/morphctrl.cpp \
+	src/spells/normals.cpp \
+	src/spells/optimize.cpp \
+	src/spells/sanitize.cpp \
+	src/spells/skeleton.cpp \
+	src/spells/stringpalette.cpp \
+	src/spells/strippify.cpp \
+	src/spells/tangentspace.cpp \
+	src/spells/texture.cpp \
+	src/spells/transform.cpp \
+	src/widgets/colorwheel.cpp \
+	src/widgets/fileselect.cpp \
+	src/widgets/floatedit.cpp \
+	src/widgets/floatslider.cpp \
+	src/widgets/groupbox.cpp \
+	src/widgets/inspect.cpp \
+	src/widgets/nifcheckboxlist.cpp \
+	src/widgets/nifeditors.cpp \
+	src/widgets/nifview.cpp \
+	src/widgets/refrbrowser.cpp \
+	src/widgets/uvedit.cpp \
+	src/widgets/valueedit.cpp \
+	src/widgets/xmlcheck.cpp \
+	src/ui/about_dialog.cpp \
+	src/ui/checkablemessagebox.cpp \
+	src/ui/settingsdialog.cpp \
+	src/version.cpp \
+	lib/half.cpp \
+	src/gl/bsshape.cpp \
+	src/material.cpp
 
 RESOURCES += \
-        res/nifskope.qrc
+	res/nifskope.qrc
 
 FORMS += \
-        src/ui/about_dialog.ui \
-        src/ui/checkablemessagebox.ui \
-        src/ui/nifskope.ui \
-        src/ui/settingsdialog.ui \
+	src/ui/about_dialog.ui \
+	src/ui/checkablemessagebox.ui \
+	src/ui/nifskope.ui \
+	src/ui/settingsdialog.ui \
     src/ui/settingsgeneral.ui \
     src/ui/settingsrender.ui \
     src/ui/settingsresources.ui
@@ -313,43 +314,43 @@ FORMS += \
 ###############################
 
 fsengine {
-        INCLUDEPATH += lib/fsengine
-        HEADERS += \
-                lib/fsengine/bsa.h \
-                lib/fsengine/fsengine.h \
-                lib/fsengine/fsmanager.h
-        SOURCES += \
-                lib/fsengine/bsa.cpp \
-                lib/fsengine/fsengine.cpp \
-                lib/fsengine/fsmanager.cpp
+	INCLUDEPATH += lib/fsengine
+	HEADERS += \
+		lib/fsengine/bsa.h \
+		lib/fsengine/fsengine.h \
+		lib/fsengine/fsmanager.h
+	SOURCES += \
+		lib/fsengine/bsa.cpp \
+		lib/fsengine/fsengine.cpp \
+		lib/fsengine/fsmanager.cpp
 }
 
 nvtristrip {
-        INCLUDEPATH += lib/NvTriStrip
-        HEADERS += \
-                lib/NvTriStrip/NvTriStrip.h \
-                lib/NvTriStrip/NvTriStripObjects.h \
-                lib/NvTriStrip/VertexCache.h
-        SOURCES += \
-                lib/NvTriStrip/NvTriStrip.cpp \
-                lib/NvTriStrip/NvTriStripObjects.cpp \
-                lib/NvTriStrip/VertexCache.cpp
+	INCLUDEPATH += lib/NvTriStrip
+	HEADERS += \
+		lib/NvTriStrip/NvTriStrip.h \
+		lib/NvTriStrip/NvTriStripObjects.h \
+		lib/NvTriStrip/VertexCache.h
+	SOURCES += \
+		lib/NvTriStrip/NvTriStrip.cpp \
+		lib/NvTriStrip/NvTriStripObjects.cpp \
+		lib/NvTriStrip/VertexCache.cpp
 }
 
 qhull {
-        INCLUDEPATH += lib/qhull/src
-        HEADERS += \
-                lib/qhull/src/libqhull/geom.h \
-                lib/qhull/src/libqhull/io.h \
-                lib/qhull/src/libqhull/libqhull.h \
-                lib/qhull/src/libqhull/mem.h \
-                lib/qhull/src/libqhull/merge.h \
-                lib/qhull/src/libqhull/poly.h \
-                lib/qhull/src/libqhull/qhull_a.h \
-                lib/qhull/src/libqhull/qset.h \
-                lib/qhull/src/libqhull/random.h \
-                lib/qhull/src/libqhull/stat.h \
-                lib/qhull/src/libqhull/user.h
+	INCLUDEPATH += lib/qhull/src
+	HEADERS += \
+		lib/qhull/src/libqhull/geom.h \
+		lib/qhull/src/libqhull/io.h \
+		lib/qhull/src/libqhull/libqhull.h \
+		lib/qhull/src/libqhull/mem.h \
+		lib/qhull/src/libqhull/merge.h \
+		lib/qhull/src/libqhull/poly.h \
+		lib/qhull/src/libqhull/qhull_a.h \
+		lib/qhull/src/libqhull/qset.h \
+		lib/qhull/src/libqhull/random.h \
+		lib/qhull/src/libqhull/stat.h \
+		lib/qhull/src/libqhull/user.h
 }
 
 soil {
@@ -369,37 +370,37 @@ soil {
 }
 
 zlib {
-        INCLUDEPATH += lib/zlib
+	INCLUDEPATH += lib/zlib
 
-        HEADERS += \
-                lib/zlib/crc32.h \
-                lib/zlib/deflate.h \
-                lib/zlib/gzguts.h \
-                lib/zlib/inffast.h \
-                lib/zlib/inffixed.h \
-                lib/zlib/inflate.h \
-                lib/zlib/inftrees.h \
-                lib/zlib/trees.h \
-                lib/zlib/zconf.h \
-                lib/zlib/zlib.h \
-                lib/zlib/zutil.h
+	HEADERS += \
+		lib/zlib/crc32.h \
+		lib/zlib/deflate.h \
+		lib/zlib/gzguts.h \
+		lib/zlib/inffast.h \
+		lib/zlib/inffixed.h \
+		lib/zlib/inflate.h \
+		lib/zlib/inftrees.h \
+		lib/zlib/trees.h \
+		lib/zlib/zconf.h \
+		lib/zlib/zlib.h \
+		lib/zlib/zutil.h
 
-        SOURCES += \
-                lib/zlib/adler32.c \
-                lib/zlib/compress.c \
-                lib/zlib/crc32.c \
-                lib/zlib/deflate.c \
-                lib/zlib/gzclose.c \
-                lib/zlib/gzlib.c \
-                lib/zlib/gzread.c \
-                lib/zlib/gzwrite.c \
-                lib/zlib/infback.c \
-                lib/zlib/inffast.c \
-                lib/zlib/inflate.c \
-                lib/zlib/inftrees.c \
-                lib/zlib/trees.c \
-                lib/zlib/uncompr.c \
-                lib/zlib/zutil.c
+	SOURCES += \
+		lib/zlib/adler32.c \
+		lib/zlib/compress.c \
+		lib/zlib/crc32.c \
+		lib/zlib/deflate.c \
+		lib/zlib/gzclose.c \
+		lib/zlib/gzlib.c \
+		lib/zlib/gzread.c \
+		lib/zlib/gzwrite.c \
+		lib/zlib/infback.c \
+		lib/zlib/inffast.c \
+		lib/zlib/inflate.c \
+		lib/zlib/inftrees.c \
+		lib/zlib/trees.c \
+		lib/zlib/uncompr.c \
+		lib/zlib/zutil.c
 }
 
 lz4 {
@@ -423,8 +424,8 @@ QMAKE_CXXFLAGS_RELEASE -= -O1
 QMAKE_CXXFLAGS_RELEASE -= -O2
 
 win32 {
-        RC_FILE = res/icon.rc
-        DEFINES += EDIT_ON_ACTIVATE
+	RC_FILE = res/icon.rc
+	DEFINES += EDIT_ON_ACTIVATE
 }
 
 # MSVC
@@ -432,38 +433,38 @@ win32 {
 #  Required: msvc2013 or higher
 *msvc* {
 
-        # Grab _MSC_VER from the mkspecs that Qt was compiled with
-        #	e.g. VS2013 = 1800, VS2012 = 1700, VS2010 = 1600
-        _MSC_VER = $$find(QMAKE_COMPILER_DEFINES, "_MSC_VER")
-        _MSC_VER = $$split(_MSC_VER, =)
-        _MSC_VER = $$member(_MSC_VER, 1)
+	# Grab _MSC_VER from the mkspecs that Qt was compiled with
+	#	e.g. VS2013 = 1800, VS2012 = 1700, VS2010 = 1600
+	_MSC_VER = $$find(QMAKE_COMPILER_DEFINES, "_MSC_VER")
+	_MSC_VER = $$split(_MSC_VER, =)
+	_MSC_VER = $$member(_MSC_VER, 1)
 
-        # Reject unsupported MSVC versions
-        !isEmpty(_MSC_VER):lessThan(_MSC_VER, 1800) {
-                error("NifSkope only supports MSVC 2013 or later. If this is too prohibitive you may use Qt Creator with MinGW.")
-        }
+	# Reject unsupported MSVC versions
+	!isEmpty(_MSC_VER):lessThan(_MSC_VER, 1800) {
+		error("NifSkope only supports MSVC 2013 or later. If this is too prohibitive you may use Qt Creator with MinGW.")
+	}
 
-        # So VCProj Filters do not flatten headers/source
-        CONFIG -= flat
+	# So VCProj Filters do not flatten headers/source
+	CONFIG -= flat
 
-        # COMPILER FLAGS
+	# COMPILER FLAGS
 
-        #  Optimization flags
-        QMAKE_CXXFLAGS_RELEASE *= -O2 -arch:SSE2 # SSE2 is the default, but make it explicit
-        #  Multithreaded compiling for Visual Studio
-        QMAKE_CXXFLAGS += -MP
+	#  Optimization flags
+	QMAKE_CXXFLAGS_RELEASE *= -O2 -arch:SSE2 # SSE2 is the default, but make it explicit
+	#  Multithreaded compiling for Visual Studio
+	QMAKE_CXXFLAGS += -MP
 
-        # LINKER FLAGS
+	# LINKER FLAGS
 
-        #  Relocate .lib and .exp files to keep release dir clean
-        QMAKE_LFLAGS += /IMPLIB:$$syspath($${INTERMEDIATE}/NifSkope.lib)
+	#  Relocate .lib and .exp files to keep release dir clean
+	QMAKE_LFLAGS += /IMPLIB:$$syspath($${INTERMEDIATE}/NifSkope.lib)
 
-        #  PDB location
-        QMAKE_LFLAGS_DEBUG += /PDB:$$syspath($${INTERMEDIATE}/nifskope.pdb)
+	#  PDB location
+	QMAKE_LFLAGS_DEBUG += /PDB:$$syspath($${INTERMEDIATE}/nifskope.pdb)
 
-        #  Clean up .embed.manifest from release dir
-        #	Fallback for `Manifest Embed` above
-        QMAKE_POST_LINK += $$QMAKE_DEL_FILE $$syspath($${DESTDIR}/*.manifest) $$nt
+	#  Clean up .embed.manifest from release dir
+	#	Fallback for `Manifest Embed` above
+	QMAKE_POST_LINK += $$QMAKE_DEL_FILE $$syspath($${DESTDIR}/*.manifest) $$nt
 }
 
 
@@ -471,18 +472,18 @@ win32 {
 #  Recommended: GCC 4.8.1+
 *-g++ {
 
-        # COMPILER FLAGS
+	# COMPILER FLAGS
 
-        #  Optimization flags
-        QMAKE_CXXFLAGS_DEBUG -= -O0 -g
-        QMAKE_CXXFLAGS_DEBUG *= -Og -g3
-        QMAKE_CXXFLAGS_RELEASE *= -O3 -mfpmath=sse
+	#  Optimization flags
+	QMAKE_CXXFLAGS_DEBUG -= -O0 -g
+	QMAKE_CXXFLAGS_DEBUG *= -Og -g3
+	QMAKE_CXXFLAGS_RELEASE *= -O3 -mfpmath=sse
 
-        # C++11 Support
-        QMAKE_CXXFLAGS_RELEASE *= -std=c++11
+	# C++11 Support
+	QMAKE_CXXFLAGS_RELEASE *= -std=c++11
 
-        #  Extension flags
-        QMAKE_CXXFLAGS_RELEASE *= -msse2 -msse
+	#  Extension flags
+	QMAKE_CXXFLAGS_RELEASE *= -msse2 -msse
 }
 
 win32 {
@@ -491,11 +492,11 @@ win32 {
 }
 
 unix:!macx {
-        LIBS += -lGLU
+	LIBS += -lGLU
 }
 
 macx {
-        LIBS += -framework CoreFoundation
+	LIBS += -framework CoreFoundation
 }
 
 
@@ -506,75 +507,75 @@ build_pass|!debug_and_release {
 ## QMAKE_PRE_LINK
 ###############################
 
-        # Find `sed` command
-        SED = $$getSed()
+	# Find `sed` command
+	SED = $$getSed()
 
-        !isEmpty(SED) {
-                # Replace @VERSION@ with number from build/VERSION
-                # Copy build/README.md.in > README.md
-                QMAKE_PRE_LINK += $${SED} -e s/@VERSION@/$${VER}/ $${PWD}/build/README.md.in > $${PWD}/README.md $$nt
-        }
+	!isEmpty(SED) {
+		# Replace @VERSION@ with number from build/VERSION
+		# Copy build/README.md.in > README.md
+		QMAKE_PRE_LINK += $${SED} -e s/@VERSION@/$${VER}/ $${PWD}/build/README.md.in > $${PWD}/README.md $$nt
+	}
 
 
 ###############################
 ## QMAKE_POST_LINK
 ###############################
 
-        win32:DEP += \
-                dep/NifMopp.dll
+	win32:DEP += \
+		dep/NifMopp.dll
 
-        XML += \
-                build/docsys/nifxml/nif.xml \
-                build/docsys/kfmxml/kfm.xml
+	XML += \
+		build/docsys/nifxml/nif.xml \
+		build/docsys/kfmxml/kfm.xml
 
-        QSS += \
-                res/style.qss
+	QSS += \
+		res/style.qss
 
-        QHULLTXT += \
-                lib/qhull/COPYING.txt
+	QHULLTXT += \
+		lib/qhull/COPYING.txt
 
-        #LANG += \
-        #	res/lang
+	#LANG += \
+	#	res/lang
 
-        SHADERS += \
-                res/shaders
+	SHADERS += \
+		res/shaders
 
-        READMES += \
-                CHANGELOG.md \
-                CONTRIBUTORS.md \
-                LICENSE.md \
-                README.md \
-                TROUBLESHOOTING.md
+	READMES += \
+		CHANGELOG.md \
+		CONTRIBUTORS.md \
+		LICENSE.md \
+		README.md \
+		TROUBLESHOOTING.md
 
 
-        copyDirs( $$SHADERS, shaders )
-        #copyDirs( $$LANG, lang )
+	copyDirs( $$SHADERS, shaders )
+	#copyDirs( $$LANG, lang )
     #copyFiles( $$XML $$QSS )
-        win32:copyFiles( $$DEP )
+	win32:copyFiles( $$DEP )
 
-        # Copy Readmes and rename to TXT
-        copyFiles( $$READMES,,,, md:txt )
+	# Copy Readmes and rename to TXT
+	copyFiles( $$READMES,,,, md:txt )
 
-        # Copy Qhull COPYING.TXT and rename
-        copyFiles( $$QHULLTXT,,, Qhull_COPYING.txt )
+	# Copy Qhull COPYING.TXT and rename
+	copyFiles( $$QHULLTXT,,, Qhull_COPYING.txt )
 
-        win32:!static {
-                # Copy DLLs to build dir
-                copyFiles( $$QtBins(),, true )
+	win32:!static {
+		# Copy DLLs to build dir
+		copyFiles( $$QtBins(),, true )
 
-                platforms += \
-                        $$[QT_INSTALL_PLUGINS]/platforms/qminimal$${DLLEXT} \
-                        $$[QT_INSTALL_PLUGINS]/platforms/qwindows$${DLLEXT}
+		platforms += \
+			$$[QT_INSTALL_PLUGINS]/platforms/qminimal$${DLLEXT} \
+			$$[QT_INSTALL_PLUGINS]/platforms/qwindows$${DLLEXT}
+		
+		imageformats += \
+			$$[QT_INSTALL_PLUGINS]/imageformats/qdds$${DLLEXT} \
+			$$[QT_INSTALL_PLUGINS]/imageformats/qjpeg$${DLLEXT} \
+			$$[QT_INSTALL_PLUGINS]/imageformats/qtga$${DLLEXT} \
+			$$[QT_INSTALL_PLUGINS]/imageformats/qwebp$${DLLEXT}
 
-                imageformats += \
-                        $$[QT_INSTALL_PLUGINS]/imageformats/qdds$${DLLEXT} \
-                        $$[QT_INSTALL_PLUGINS]/imageformats/qjpeg$${DLLEXT} \
-                        $$[QT_INSTALL_PLUGINS]/imageformats/qtga$${DLLEXT} \
-                        $$[QT_INSTALL_PLUGINS]/imageformats/qwebp$${DLLEXT}
-
-                copyFiles( $$platforms, platforms, true )
-                copyFiles( $$imageformats, imageformats, true )
-        }
+		copyFiles( $$platforms, platforms, true )
+		copyFiles( $$imageformats, imageformats, true )
+	}
 
 } # end build_pass
 
@@ -582,24 +583,24 @@ build_pass|!debug_and_release {
 # Build Messages
 # (Add `buildMessages` to CONFIG to use)
 buildMessages:build_pass|buildMessages:!debug_and_release {
-        CONFIG(debug, debug|release) {
-                message("Debug Mode")
-        } CONFIG(release, release|debug) {
-                message("Release Mode")
-        }
+	CONFIG(debug, debug|release) {
+		message("Debug Mode")
+	} CONFIG(release, release|debug) {
+		message("Release Mode")
+	}
 
-        message(mkspec _______ $$QMAKESPEC)
-        message(cxxflags _____ $$QMAKE_CXXFLAGS)
-        message(arch _________ $$QMAKE_TARGET.arch)
-        message(src __________ $$PWD)
-        message(build ________ $$OUT_PWD)
-        message(Qt binaries __ $$[QT_INSTALL_BINS])
+	message(mkspec _______ $$QMAKESPEC)
+	message(cxxflags _____ $$QMAKE_CXXFLAGS)
+	message(arch _________ $$QMAKE_TARGET.arch)
+	message(src __________ $$PWD)
+	message(build ________ $$OUT_PWD)
+	message(Qt binaries __ $$[QT_INSTALL_BINS])
 
-        build_pass:equals( VISUALSTUDIO, true ) {
-                message(Visual Studio __ Yes)
-        }
+	build_pass:equals( VISUALSTUDIO, true ) {
+		message(Visual Studio __ Yes)
+	}
 
-        #message($$CONFIG)
+	#message($$CONFIG)
 }
 
-# vim: set filetype=config :
+# vim: set filetype=config : 

--- a/NifSkope.pro
+++ b/NifSkope.pro
@@ -17,8 +17,7 @@ contains(QT_VERSION, ^5\\.[0-4]\\..*) {
 CONFIG += c++11
 
 # Dependencies
-CONFIG += nvtristrip qhull soil zlib lz4
-win32:CONFIG += fsengine
+CONFIG += nvtristrip qhull soil zlib lz4 fsengine
 
 # Debug/Release options
 CONFIG(debug, debug|release) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,12 @@
 version: "{build}"
 
 platform:
-    - Win32
+    - win32
     - x64
 
-configuration: Debug
+configuration:
+    - debug
+    - release
 
 matrix:
     fast_finish: true
@@ -18,27 +20,31 @@ clone_depth: 1
 clone_folder: C:\projects\nifskope
 
 install:
-    - if %PLATFORM%==Win32 set QTDIR=C:\Qt\5.6\msvc2015
+    - if %PLATFORM%==win32 set QTDIR=C:\Qt\5.6\msvc2015
     - if %PLATFORM%==x64 set QTDIR=C:\Qt\5.6\msvc2015_64
     - set PATH=%PATH%;%QTDIR%\bin;
 
 build_script:
     - git submodule update --init --recursive # Appveyor doesn't clone recursively.
-    - qmake -Wall -spec win32-msvc2015 -tp vc NifSkope.pro
-    - dir C:\projects\nifskope
-    - dir C:\projects\nifskope\release
+    - qmake CONFIG+=%CONFIGURATION% -Wall -spec win32-msvc2015 -tp vc NifSkope.pro
     - msbuild NifSkope.vcxproj /t:Build /p:Configuration=%configuration% /m:2 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 after_build:
-    - dir C:\projects\nifskope
-    - dir C:\projects\nifskope\release
-    - if %PLATFORM%==Win32 7z a nifskope_x32.zip %APPVEYOR_BUILD_FOLDER%
-    - if %PLATFORM%==x64 7z a nifskope_x64.zip %APPVEYOR_BUILD_FOLDER%
+    - if %CONFIGURATION%==debug set DEBUG_POSTFIX=_debug
+    - set BUILD_DIR=%APPVEYOR_BUILD_FOLDER%\bin\%CONFIGURATION%
+    - set BUILD_NAME=nifskope_%platform%%DEBUG_POSTFIX%.zip
+    - 7z a %BUILD_NAME% %BUILD_DIR%
+    - 7z rn %BUILD_NAME% %CONFIGURATION% NifSkope
 
 test: off
 
 artifacts:
-    - path: nifskope_x32.zip
-      name: nifskope_x32
+    - path: nifskope_win32.zip
+      name: nifskope_win32
     - path: nifskope_x64.zip
       name: nifskope_x64
+    - path: nifskope_win32_debug.zip
+      name: nifskope_win32_debug
+    - path: nifskope_x64_debug.zip
+      name: nifskope_x64_debug
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,24 +23,22 @@ install:
     - set PATH=%PATH%;%QTDIR%\bin;
 
 build_script:
-#    - if %PLATFORM%==Win32 set build=Build_32
-#    - if %PLATFORM%==x64 set build=Build_64
     - git submodule update --init --recursive # Appveyor doesn't clone recursively.
     - qmake -Wall -spec win32-msvc2015 -tp vc NifSkope.pro
     - dir C:\projects\nifskope
-    - dir C:\projects\nifskope\build
+    - dir C:\projects\nifskope\release
     - msbuild NifSkope.vcxproj /t:Build /p:Configuration=%configuration% /m:2 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 after_build:
     - dir C:\projects\nifskope
-    - dir C:\projects\nifskope\build
-#    - if %PLATFORM%==Win32 7z a nifskope_x32.zip %APPVEYOR_BUILD_FOLDER%\Build_32\Debug\nifskope*
-#    - if %PLATFORM%==x64 7z a nifskope_x64.zip %APPVEYOR_BUILD_FOLDER%\Build_64\Debug\nifskope*
+    - dir C:\projects\nifskope\release
+    - if %PLATFORM%==Win32 7z a nifskope_x32.zip %APPVEYOR_BUILD_FOLDER%
+    - if %PLATFORM%==x64 7z a nifskope_x64.zip %APPVEYOR_BUILD_FOLDER%
 
 test: off
 
-#artifacts:
-#    - path: nifskope_x32.zip
-#      name: nifskope_x32
-#    - path: nifskope_x64.zip
-#      name: nifskope_x64
+artifacts:
+    - path: nifskope_x32.zip
+      name: nifskope_x32
+    - path: nifskope_x64.zip
+      name: nifskope_x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,46 @@
+version: "{build}"
+
+platform:
+    - Win32
+    - x64
+
+configuration: Debug
+
+matrix:
+    fast_finish: true
+
+os: Visual Studio 2015
+
+# We want the git revision for versioning,
+# so shallow clones don't work.
+clone_depth: 1
+
+clone_folder: C:\projects\nifskope
+
+install:
+    - if %PLATFORM%==Win32 set QTDIR=C:\Qt\5.6\msvc2015
+    - if %PLATFORM%==x64 set QTDIR=C:\Qt\5.6\msvc2015_64
+    - set PATH=%PATH%;%QTDIR%\bin;
+
+build_script:
+#    - if %PLATFORM%==Win32 set build=Build_32
+#    - if %PLATFORM%==x64 set build=Build_64
+    - git submodule update --init --recursive # Appveyor doesn't clone recursively.
+    - qmake -Wall -spec win32-msvc2015 -tp vc NifSkope.pro
+    - dir C:\projects\nifskope
+    - dir C:\projects\nifskope\build
+    - msbuild NifSkope.vcxproj /t:Build /p:Configuration=%configuration% /m:2 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+after_build:
+    - dir C:\projects\nifskope
+    - dir C:\projects\nifskope\build
+#    - if %PLATFORM%==Win32 7z a nifskope_x32.zip %APPVEYOR_BUILD_FOLDER%\Build_32\Debug\nifskope*
+#    - if %PLATFORM%==x64 7z a nifskope_x64.zip %APPVEYOR_BUILD_FOLDER%\Build_64\Debug\nifskope*
+
+test: off
+
+#artifacts:
+#    - path: nifskope_x32.zip
+#      name: nifskope_x32
+#    - path: nifskope_x64.zip
+#      name: nifskope_x64

--- a/lib/dds.h
+++ b/lib/dds.h
@@ -1,19 +1,29 @@
 //--------------------------------------------------------------------------------------
 // dds.h
 //
-// This header defines constants and structures that are useful when parsing 
+// This header defines constants and structures that are useful when parsing
 // DDS files.  DDS files were originally designed to use several structures
 // and constants that are native to DirectDraw and are defined in ddraw.h,
-// such as DDSURFACEDESC2 and DDSCAPS2.  This file defines similar 
-// (compatible) constants and structures so that one can use DDS files 
+// such as DDSURFACEDESC2 and DDSCAPS2.  This file defines similar
+// (compatible) constants and structures so that one can use DDS files
 // without needing to include ddraw.h.
 //--------------------------------------------------------------------------------------
 
 #ifndef _DDS_H_
 #define _DDS_H_
 
-#include <windows.h>
 #include <dxgiformat.h>
+
+typedef unsigned char BYTE;
+typedef unsigned short WORD;
+typedef unsigned long DWORD;
+
+#ifndef MAKEFOURCC
+    #define MAKEFOURCC(ch0, ch1, ch2, ch3)                              \
+                ((DWORD)(BYTE)(ch0) | ((DWORD)(BYTE)(ch1) << 8) |   \
+                ((DWORD)(BYTE)(ch2) << 16) | ((DWORD)(BYTE)(ch3) << 24 ))
+#endif //defined(MAKEFOURCC)
+
 
 #pragma pack(push,1)
 
@@ -71,7 +81,7 @@ const DDS_PIXELFORMAT DDSPF_R5G6B5 =
 const DDS_PIXELFORMAT DDSPF_DX10 =
     { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','1','0'), 0, 0, 0, 0, 0 };
 
-#define DDS_HEADER_FLAGS_TEXTURE        0x00001007  // DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PIXELFORMAT 
+#define DDS_HEADER_FLAGS_TEXTURE        0x00001007  // DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PIXELFORMAT
 #define DDS_HEADER_FLAGS_MIPMAP         0x00020000  // DDSD_MIPMAPCOUNT
 #define DDS_HEADER_FLAGS_VOLUME         0x00800000  // DDSD_DEPTH
 #define DDS_HEADER_FLAGS_PITCH          0x00000008  // DDSD_PITCH
@@ -138,7 +148,7 @@ typedef struct
     DWORD dwReserved2[3];
 } DDS_HEADER;
 
-typedef struct 
+typedef struct
 {
     DXGI_FORMAT dxgiFormat;
     DDS_RESOURCE_DIMENSION resourceDimension;

--- a/lib/dxgiformat.h
+++ b/lib/dxgiformat.h
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2007 Andras Kovacs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/*
+ * Oracle LGPL Disclaimer: For the avoidance of doubt, except that if any license choice
+ * other than GPL or LGPL is available it will apply instead, Oracle elects to use only
+ * the Lesser General Public License version 2.1 (LGPLv2) at this time for any software where
+ * a choice of LGPL license versions is made available with the language indicating
+ * that LGPLv2 or any later version may be used, or where a choice of which version
+ * of the LGPL is applied is otherwise unspecified.
+ */
+
+#ifndef __dxgiformat_h__
+#define __dxgiformat_h__
+
+#define DXGI_FORMAT_DEFINED 1
+
+typedef enum DXGI_FORMAT {
+    DXGI_FORMAT_UNKNOWN                 = 0,
+    DXGI_FORMAT_R32G32B32A32_TYPELESS   = 1,
+    DXGI_FORMAT_R32G32B32A32_FLOAT      = 2,
+    DXGI_FORMAT_R32G32B32A32_UINT       = 3,
+    DXGI_FORMAT_R32G32B32A32_SINT       = 4,
+    DXGI_FORMAT_R32G32B32_TYPELESS      = 5,
+    DXGI_FORMAT_R32G32B32_FLOAT         = 6,
+    DXGI_FORMAT_R32G32B32_UINT          = 7,
+    DXGI_FORMAT_R32G32B32_SINT          = 8,
+    DXGI_FORMAT_R16G16B16A16_TYPELESS   = 9,
+    DXGI_FORMAT_R16G16B16A16_FLOAT      = 10,
+    DXGI_FORMAT_R16G16B16A16_UNORM      = 11,
+    DXGI_FORMAT_R16G16B16A16_UINT       = 12,
+    DXGI_FORMAT_R16G16B16A16_SNORM      = 13,
+    DXGI_FORMAT_R16G16B16A16_SINT       = 14,
+    DXGI_FORMAT_R32G32_TYPELESS         = 15,
+    DXGI_FORMAT_R32G32_FLOAT            = 16,
+    DXGI_FORMAT_R32G32_UINT             = 17,
+    DXGI_FORMAT_R32G32_SINT             = 18,
+    DXGI_FORMAT_R32G8X24_TYPELESS       = 19,
+    DXGI_FORMAT_D32_FLOAT_S8X24_UINT    = 20,
+    DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS= 21,
+    DXGI_FORMAT_X32_TYPELESS_G8X24_UINT = 22,
+    DXGI_FORMAT_R10G10B10A2_TYPELESS    = 23,
+    DXGI_FORMAT_R10G10B10A2_UNORM       = 24,
+    DXGI_FORMAT_R10G10B10A2_UINT        = 25,
+    DXGI_FORMAT_R11G11B10_FLOAT         = 26,
+    DXGI_FORMAT_R8G8B8A8_TYPELESS       = 27,
+    DXGI_FORMAT_R8G8B8A8_UNORM          = 28,
+    DXGI_FORMAT_R8G8B8A8_UNORM_SRGB     = 29,
+    DXGI_FORMAT_R8G8B8A8_UINT           = 30,
+    DXGI_FORMAT_R8G8B8A8_SNORM          = 31,
+    DXGI_FORMAT_R8G8B8A8_SINT           = 32,
+    DXGI_FORMAT_R16G16_TYPELESS         = 33,
+    DXGI_FORMAT_R16G16_FLOAT            = 34,
+    DXGI_FORMAT_R16G16_UNORM            = 35,
+    DXGI_FORMAT_R16G16_UINT             = 36,
+    DXGI_FORMAT_R16G16_SNORM            = 37,
+    DXGI_FORMAT_R16G16_SINT             = 38,
+    DXGI_FORMAT_R32_TYPELESS            = 39,
+    DXGI_FORMAT_D32_FLOAT               = 40,
+    DXGI_FORMAT_R32_FLOAT               = 41,
+    DXGI_FORMAT_R32_UINT                = 42,
+    DXGI_FORMAT_R32_SINT                = 43,
+    DXGI_FORMAT_R24G8_TYPELESS          = 44,
+    DXGI_FORMAT_D24_UNORM_S8_UINT       = 45,
+    DXGI_FORMAT_R24_UNORM_X8_TYPELESS   = 46,
+    DXGI_FORMAT_X24_TYPELESS_G8_UINT    = 47,
+    DXGI_FORMAT_R8G8_TYPELESS           = 48,
+    DXGI_FORMAT_R8G8_UNORM              = 49,
+    DXGI_FORMAT_R8G8_UINT               = 50,
+    DXGI_FORMAT_R8G8_SNORM              = 51,
+    DXGI_FORMAT_R8G8_SINT               = 52,
+    DXGI_FORMAT_R16_TYPELESS            = 53,
+    DXGI_FORMAT_R16_FLOAT               = 54,
+    DXGI_FORMAT_D16_UNORM               = 55,
+    DXGI_FORMAT_R16_UNORM               = 56,
+    DXGI_FORMAT_R16_UINT                = 57,
+    DXGI_FORMAT_R16_SNORM               = 58,
+    DXGI_FORMAT_R16_SINT                = 59,
+    DXGI_FORMAT_R8_TYPELESS             = 60,
+    DXGI_FORMAT_R8_UNORM                = 61,
+    DXGI_FORMAT_R8_UINT                 = 62,
+    DXGI_FORMAT_R8_SNORM                = 63,
+    DXGI_FORMAT_R8_SINT                 = 64,
+    DXGI_FORMAT_A8_UNORM                = 65,
+    DXGI_FORMAT_R1_UNORM                = 66,
+    DXGI_FORMAT_R9G9B9E5_SHAREDEXP      = 67,
+    DXGI_FORMAT_R8G8_B8G8_UNORM         = 68,
+    DXGI_FORMAT_G8R8_G8B8_UNORM         = 69,
+    DXGI_FORMAT_BC1_TYPELESS            = 70,
+    DXGI_FORMAT_BC1_UNORM               = 71,
+    DXGI_FORMAT_BC1_UNORM_SRGB          = 72,
+    DXGI_FORMAT_BC2_TYPELESS            = 73,
+    DXGI_FORMAT_BC2_UNORM               = 74,
+    DXGI_FORMAT_BC2_UNORM_SRGB          = 75,
+    DXGI_FORMAT_BC3_TYPELESS            = 76,
+    DXGI_FORMAT_BC3_UNORM               = 77,
+    DXGI_FORMAT_BC3_UNORM_SRGB          = 78,
+    DXGI_FORMAT_BC4_TYPELESS            = 79,
+    DXGI_FORMAT_BC4_UNORM               = 80,
+    DXGI_FORMAT_BC4_SNORM               = 81,
+    DXGI_FORMAT_BC5_TYPELESS            = 82,
+    DXGI_FORMAT_BC5_UNORM               = 83,
+    DXGI_FORMAT_BC5_SNORM               = 84,
+    DXGI_FORMAT_B5G6R5_UNORM            = 85,
+    DXGI_FORMAT_B5G5R5A1_UNORM          = 86,
+    DXGI_FORMAT_B8G8R8A8_UNORM          = 87,
+    DXGI_FORMAT_B8G8R8X8_UNORM          = 88,
+    DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM = 89,
+    DXGI_FORMAT_B8G8R8A8_TYPELESS       = 90,
+    DXGI_FORMAT_B8G8R8A8_UNORM_SRGB     = 91,
+    DXGI_FORMAT_B8G8R8X8_TYPELESS       = 92,
+    DXGI_FORMAT_B8G8R8X8_UNORM_SRGB     = 93,
+    DXGI_FORMAT_BC6H_TYPELESS           = 94,
+    DXGI_FORMAT_BC6H_UF16               = 95,
+    DXGI_FORMAT_BC6H_SF16               = 96,
+    DXGI_FORMAT_BC7_TYPELESS            = 97,
+    DXGI_FORMAT_BC7_UNORM               = 98,
+    DXGI_FORMAT_BC7_UNORM_SRGB          = 99,
+    DXGI_FORMAT_AYUV                    = 100,
+    DXGI_FORMAT_Y410                    = 101,
+    DXGI_FORMAT_Y416                    = 102,
+    DXGI_FORMAT_NV12                    = 103,
+    DXGI_FORMAT_P010                    = 104,
+    DXGI_FORMAT_P016                    = 105,
+    DXGI_FORMAT_420_OPAQUE              = 106,
+    DXGI_FORMAT_YUY2                    = 107,
+    DXGI_FORMAT_Y210                    = 108,
+    DXGI_FORMAT_Y216                    = 109,
+    DXGI_FORMAT_NV11                    = 110,
+    DXGI_FORMAT_AI44                    = 111,
+    DXGI_FORMAT_IA44                    = 112,
+    DXGI_FORMAT_P8                      = 113,
+    DXGI_FORMAT_A8P8                    = 114,
+    DXGI_FORMAT_B4G4R4A4_UNORM          = 115,
+    DXGI_FORMAT_FORCE_UINT              = 0xffffffff
+} DXGI_FORMAT;
+
+#endif

--- a/src/gl/dds/ColorBlock.cpp
+++ b/src/gl/dds/ColorBlock.cpp
@@ -79,8 +79,8 @@ ColorBlock::ColorBlock( const Image * img, uint x, uint y )
 
 void ColorBlock::init( const Image * img, uint x, uint y )
 {
-	const uint bw = fmin( img->width() - x, 4U );
-	const uint bh = fmin( img->height() - y, 4U );
+	const uint bw = std::min( img->width() - x, 4U );
+	const uint bh = std::min( img->height() - y, 4U );
 
 	static int remainder[] = {
 		0, 0, 0, 0,

--- a/src/gl/dds/ColorBlock.cpp
+++ b/src/gl/dds/ColorBlock.cpp
@@ -42,7 +42,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "ColorBlock.h"
 
 #include "Common.h"
-
+#include <math.h>
 
 // Get approximate luminance.
 inline static uint colorLuminance( Color32 c )
@@ -79,8 +79,8 @@ ColorBlock::ColorBlock( const Image * img, uint x, uint y )
 
 void ColorBlock::init( const Image * img, uint x, uint y )
 {
-	const uint bw = min( img->width() - x, 4U );
-	const uint bh = min( img->height() - y, 4U );
+	const uint bw = fmin( img->width() - x, 4U );
+	const uint bh = fmin( img->height() - y, 4U );
 
 	static int remainder[] = {
 		0, 0, 0, 0,

--- a/src/gl/dds/Common.h
+++ b/src/gl/dds/Common.h
@@ -33,8 +33,10 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _DDS_COMMON_H
 #define _DDS_COMMON_H
 
+#include <algorithm>
+
 #ifndef clamp
-#define clamp( x, a, b ) fmin( fmax( (x), (a) ), (b) )
+#define clamp( x, a, b ) std::min( std::max( (x), (a) ), (b) )
 #endif
 
 template <typename T>

--- a/src/gl/dds/Common.h
+++ b/src/gl/dds/Common.h
@@ -33,14 +33,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _DDS_COMMON_H
 #define _DDS_COMMON_H
 
-#ifndef min
-#define min( a, b ) ( (a) <= (b) ? (a) : (b) )
-#endif
-#ifndef max
-#define max( a, b ) ( (a) >= (b) ? (a) : (b) )
-#endif
 #ifndef clamp
-#define clamp( x, a, b ) min( max( (x), (a) ), (b) )
+#define clamp( x, a, b ) fmin( fmax( (x), (a) ), (b) )
 #endif
 
 template <typename T>

--- a/src/gl/dds/DirectDrawSurface.cpp
+++ b/src/gl/dds/DirectDrawSurface.cpp
@@ -689,8 +689,8 @@ void DirectDrawSurface::mipmap( Image * img, uint face, uint mipmap )
 
 	// Compute width and height.
 	for ( uint m = 0; m < mipmap; m++ ) {
-		w = fmax( 1U, w / 2 );
-		h = fmax( 1U, h / 2 );
+		w = std::max( 1U, w / 2 );
+		h = std::max( 1U, h / 2 );
 	}
 
 	img->allocate( w, h );
@@ -776,8 +776,8 @@ void DirectDrawSurface::readBlockImage( Image * img )
 			readBlock( &block );
 
 			// Write color block.
-			for ( uint y = 0; y < fmin( 4U, h - 4 * by ); y++ ) {
-				for ( uint x = 0; x < fmin( 4U, w - 4 * bx ); x++ ) {
+			for ( uint y = 0; y < std::min( 4U, h - 4 * by ); y++ ) {
+				for ( uint x = 0; x < std::min( 4U, w - 4 * bx ); x++ ) {
 					img->pixel( 4 * bx + x, 4 * by + y ) = block.color( x, y );
 				}
 			}
@@ -883,9 +883,9 @@ uint DirectDrawSurface::mipmapSize( uint mipmap ) const
 	uint d = depth();
 
 	for ( uint m = 0; m < mipmap; m++ ) {
-		w = fmax( 1U, w / 2 );
-		h = fmax( 1U, h / 2 );
-		d = fmax( 1U, d / 2 );
+		w = std::max( 1U, w / 2 );
+		h = std::max( 1U, h / 2 );
+		d = std::max( 1U, d / 2 );
 	}
 
 	if ( header.pf.flags & DDPF_FOURCC ) {

--- a/src/gl/dds/DirectDrawSurface.cpp
+++ b/src/gl/dds/DirectDrawSurface.cpp
@@ -689,8 +689,8 @@ void DirectDrawSurface::mipmap( Image * img, uint face, uint mipmap )
 
 	// Compute width and height.
 	for ( uint m = 0; m < mipmap; m++ ) {
-		w = max( 1U, w / 2 );
-		h = max( 1U, h / 2 );
+		w = fmax( 1U, w / 2 );
+		h = fmax( 1U, h / 2 );
 	}
 
 	img->allocate( w, h );
@@ -776,8 +776,8 @@ void DirectDrawSurface::readBlockImage( Image * img )
 			readBlock( &block );
 
 			// Write color block.
-			for ( uint y = 0; y < min( 4U, h - 4 * by ); y++ ) {
-				for ( uint x = 0; x < min( 4U, w - 4 * bx ); x++ ) {
+			for ( uint y = 0; y < fmin( 4U, h - 4 * by ); y++ ) {
+				for ( uint x = 0; x < fmin( 4U, w - 4 * bx ); x++ ) {
 					img->pixel( 4 * bx + x, 4 * by + y ) = block.color( x, y );
 				}
 			}
@@ -883,9 +883,9 @@ uint DirectDrawSurface::mipmapSize( uint mipmap ) const
 	uint d = depth();
 
 	for ( uint m = 0; m < mipmap; m++ ) {
-		w = max( 1U, w / 2 );
-		h = max( 1U, h / 2 );
-		d = max( 1U, d / 2 );
+		w = fmax( 1U, w / 2 );
+		h = fmax( 1U, h / 2 );
+		d = fmax( 1U, d / 2 );
 	}
 
 	if ( header.pf.flags & DDPF_FOURCC ) {

--- a/src/gl/gltexloaders.cpp
+++ b/src/gl/gltexloaders.cpp
@@ -1898,8 +1898,8 @@ bool texSaveNIF( NifModel * nif, const QString & filepath, QModelIndex & iData )
 
 			// generate next offset, resize
 			mipmapOffset += mipmapWidth * mipmapHeight * 4;
-			mipmapWidth   = fmax( 1, mipmapWidth / 2 );
-			mipmapHeight  = fmax( 1, mipmapHeight / 2 );
+			mipmapWidth   = std::max( 1, mipmapWidth / 2 );
+			mipmapHeight  = std::max( 1, mipmapHeight / 2 );
 		}
 
 		// set total pixel size
@@ -2065,9 +2065,9 @@ bool texSaveNIF( NifModel * nif, const QString & filepath, QModelIndex & iData )
 
 			if ( ddsHeader.ddsPixelFormat.dwFlags & DDPF_FOURCC ) {
 				if ( ddsHeader.ddsPixelFormat.dwFourCC == FOURCC_DXT1 ) {
-					mipmapOffset += fmax( 8, ( mipmapWidth * mipmapHeight / 2 ) );
+					mipmapOffset += std::max( 8, ( mipmapWidth * mipmapHeight / 2 ) );
 				} else if ( ddsHeader.ddsPixelFormat.dwFourCC == FOURCC_DXT5 ) {
-					mipmapOffset += fmax( 16, ( mipmapWidth * mipmapHeight ) );
+					mipmapOffset += std::max( 16, ( mipmapWidth * mipmapHeight ) );
 				}
 			} else if ( ddsHeader.ddsPixelFormat.dwBPP == 24 ) {
 				mipmapOffset += ( mipmapWidth * mipmapHeight * 3 );
@@ -2075,8 +2075,8 @@ bool texSaveNIF( NifModel * nif, const QString & filepath, QModelIndex & iData )
 				mipmapOffset += ( mipmapWidth * mipmapHeight * 4 );
 			}
 
-			mipmapWidth  = fmax( 1, mipmapWidth / 2 );
-			mipmapHeight = fmax( 1, mipmapHeight / 2 );
+			mipmapWidth  = std::max( 1, mipmapWidth / 2 );
+			mipmapHeight = std::max( 1, mipmapHeight / 2 );
 		}
 
 		nif->set<quint32>( iData, "Num Pixels", mipmapOffset );

--- a/src/gl/gltexloaders.cpp
+++ b/src/gl/gltexloaders.cpp
@@ -1898,8 +1898,8 @@ bool texSaveNIF( NifModel * nif, const QString & filepath, QModelIndex & iData )
 
 			// generate next offset, resize
 			mipmapOffset += mipmapWidth * mipmapHeight * 4;
-			mipmapWidth   = max( 1, mipmapWidth / 2 );
-			mipmapHeight  = max( 1, mipmapHeight / 2 );
+			mipmapWidth   = fmax( 1, mipmapWidth / 2 );
+			mipmapHeight  = fmax( 1, mipmapHeight / 2 );
 		}
 
 		// set total pixel size
@@ -2065,9 +2065,9 @@ bool texSaveNIF( NifModel * nif, const QString & filepath, QModelIndex & iData )
 
 			if ( ddsHeader.ddsPixelFormat.dwFlags & DDPF_FOURCC ) {
 				if ( ddsHeader.ddsPixelFormat.dwFourCC == FOURCC_DXT1 ) {
-					mipmapOffset += max( 8, ( mipmapWidth * mipmapHeight / 2 ) );
+					mipmapOffset += fmax( 8, ( mipmapWidth * mipmapHeight / 2 ) );
 				} else if ( ddsHeader.ddsPixelFormat.dwFourCC == FOURCC_DXT5 ) {
-					mipmapOffset += max( 16, ( mipmapWidth * mipmapHeight ) );
+					mipmapOffset += fmax( 16, ( mipmapWidth * mipmapHeight ) );
 				}
 			} else if ( ddsHeader.ddsPixelFormat.dwBPP == 24 ) {
 				mipmapOffset += ( mipmapWidth * mipmapHeight * 3 );
@@ -2075,8 +2075,8 @@ bool texSaveNIF( NifModel * nif, const QString & filepath, QModelIndex & iData )
 				mipmapOffset += ( mipmapWidth * mipmapHeight * 4 );
 			}
 
-			mipmapWidth  = max( 1, mipmapWidth / 2 );
-			mipmapHeight = max( 1, mipmapHeight / 2 );
+			mipmapWidth  = fmax( 1, mipmapWidth / 2 );
+			mipmapHeight = fmax( 1, mipmapHeight / 2 );
 		}
 
 		nif->set<quint32>( iData, "Num Pixels", mipmapOffset );


### PR DESCRIPTION
This is a cross-platform fix that should allow for building on Linux (tested), Windows (untested) and MacOS (untested).

-  use fmin/fmax as they are provided for us in C++11, removed min/max
-  removed windows.h 
-  added additional typedefs and defines 
-  use a gpl version of dxgiformat
-  also replaced tabs with spaces because tabs are evil ;)

To compile on Debian and Ubuntu, I use:
```
/usr/lib/x86_64-linux-gnu/qt5/bin/qmake -makefile NifSkope.pro
```