### PR TITLE
Add support for 64 bit cygwin on finding sedpath

### DIFF
--- a/NifSkope_functions.pri
+++ b/NifSkope_functions.pri
@@ -26,12 +26,15 @@ defineReplace(getSed) {
 
 		GNUWIN32 = $${PROG}/GnuWin32/bin
 		CYGWIN = C:/cygwin/bin
+		CYGWIN64 = C:/cygwin64/bin
 		SEDPATH = /sed.exe
 
 		exists($${GNUWIN32}$${SEDPATH}) {
 			sedbin = \"$${GNUWIN32}$${SEDPATH}\"
 		} else:exists($${CYGWIN}$${SEDPATH}) {
 			sedbin = \"$${CYGWIN}$${SEDPATH}\"
+		} else:exists($${CYGWIN64}$${SEDPATH}) {
+			sedbin = \"$${CYGWIN64}$${SEDPATH}\"
 		} else {
 			#message(Neither GnuWin32 or Cygwin were found)
 			sedbin = $$system(where sed 2> NUL)


### PR DESCRIPTION
This commit just makes basic changes to the .pri file to be able to find sed.exe from a 64 bit cygwin path.