### PR TITLE
Compilation error in class `LightingWidget`

### DIFF
--- a/src/ui/widgets/lightingwidget.h
+++ b/src/ui/widgets/lightingwidget.h
@@ -2,11 +2,11 @@
 #define LIGHTINGWIDGET_H
 
 #include <QWidget>
+#include <QAction>
 
 #include <memory>
 
 class GLView;
-class QAction;
 
 namespace Ui {
 class LightingWidget;


### PR DESCRIPTION
I have the following error when compiling under Linux:
```
src/ui/widgets/lightingwidget.cpp:72:76: error: incomplete type ‘QAction’ used in nested name specifier
  connect( ui->btnLighting, &QToolButton::toggled, atns.value(3), &QAction::setEnabled );
                                                                            ^~~~~~~~~~
```
The proposed change fixes it for me, and the program compiles and runs correctly (although I did not do any in depth tests). 